### PR TITLE
Enable Model Level Benchmarking

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+from .bench import DlightBench
+from .models import *

--- a/bench.py
+++ b/bench.py
@@ -8,7 +8,7 @@ from tvm.ir.transform import ModulePass
 
 from tvm import dlight as dl
 from tvm.dlight.benchmark import benchmark_prim_func
-from tvm.dlight.benchmark.utils import random_dym_var_sample_func
+from tvm.dlight.benchmark.utils import random_dym_var_sample_func, DisplayConfig
 
 CATEGORY = Literal[
     "Reduction", "GEMV", "Fallback", "Matmul", "Transpose", "GeneralReduction"
@@ -160,6 +160,9 @@ class DlightBench:
                 prim_func_name=func_name,
                 evaluator_config=evaluator_config,
                 rpc_config=rpc_config,
-                drop_cols=["Weight", "WxTime(ms)", "Std(us)", "PrimFunc"],
+                display_config=DisplayConfig(
+                    print_out=True,
+                    hidden_cols=["Weight", "WxTime(ms)", "Std(us)", "PrimFunc"],
+                ),
             )
             print()

--- a/bench.py
+++ b/bench.py
@@ -1,0 +1,127 @@
+"""The model benchmark for dlight."""
+from typing import TYPE_CHECKING, Dict, List, Callable, Union, Optional
+
+import tvm
+from tvm.tir import PrimFunc
+from tvm.ir import IRModule
+from tvm.ir.transform import ModulePass
+from tvm.dlight.benchmark import benchmark_prim_func
+from tvm.dlight.benchmark.utils import default_dym_var_sample_func
+
+if TYPE_CHECKING:
+    from tvm.meta_schedule.runner import RPCConfig, EvaluatorConfig
+
+
+class DlightBench:
+    """The class to register benchmark workloads and run benchmark.
+
+    Parameters
+    ----------
+    workloads : Dict[str, Dict[str, PrimFunc]]
+        The dictionary of benchmark workloads.
+    """
+
+    workloads: Dict[str, Dict[str, PrimFunc]] = {}
+
+    @staticmethod
+    def register_bench_workload(
+        mod_or_func: Union[IRModule, PrimFunc], model_name: str, func_name: str
+    ):
+        """Register a benchmark workload.
+
+        Parameters
+        ----------
+        mod_or_func : Union[IRModule, PrimFunc]
+            The IRModule or PrimFunc to be registered.
+        workload_name : str
+            The workload name.
+        func_name : str
+            The function name.
+        """
+        if isinstance(mod_or_func, IRModule):
+            func = mod_or_func[func_name]
+        elif isinstance(mod_or_func, PrimFunc):
+            func = mod_or_func
+        else:
+            raise TypeError("Unsupported type: " + str(type(mod_or_func)))
+
+        if model_name not in DlightBench.workloads:
+            DlightBench.workloads[model_name] = {}
+        # if func_name in DlightBench.workloads[model_name]:
+        #     raise ValueError("Workload already registered: " + func_name)
+
+        DlightBench.workloads[model_name][func_name] = func
+
+    @staticmethod
+    def benchmark(
+        model_name: str,
+        *,
+        passes: List[Union[ModulePass, Callable]],
+        func_name: Optional[str] = None,
+        sample_func: Optional[
+            Callable[[Dict[str, str], int, int], Dict[str, int]]
+        ] = None,
+        target: Optional[tvm.target.Target] = None,
+        sample_num_per_func: int = 5,
+        evaluator_config: Optional["EvaluatorConfig"] = None,
+        rpc_config: Optional["RPCConfig"] = None,
+    ) -> None:
+        """Run benchmark.
+
+        Parameters
+        ----------
+        model_name : str
+            The model name.
+        passes : List[Union[ModulePass, Callable]]
+            The passes to be applied to the PrimFuncs.
+        func_name : Optional[str]
+            The function name to specify the workload, if None, benchmark all
+            functions in the model.
+        sample_func : Optional[Callable[[Dict[str, str], int, int], Dict[str, int]]]
+            The function to sample dynamic shape variables, if None, use the
+            default function.
+        target : Optional[tvm.target.Target]
+            The target to run benchmark, if None, use the current target.
+        sample_num_per_func : int
+            The number of samples per function, default is 5.
+        evaluator_config : Optional["EvaluatorConfig"]
+            The evaluator config, if None, use the default config.
+        rpc_config : Optional["RPCConfig"]
+            The RPC config, if None, use the default config.
+        """
+        if sample_func is None:
+            sample_func = default_dym_var_sample_func
+        if target is None:
+            target = tvm.target.Target.current()
+            assert target is not None, "No target specified."
+        if model_name not in DlightBench.workloads:
+            raise ValueError("Model not registered: " + model_name)
+        if func_name is None:
+            func_names = [func_name for func_name in DlightBench.workloads[model_name]]
+        else:
+            func_names = [func_name]
+
+        # Run benchmark
+        print("Model:", model_name)
+        print("Target:", target)
+        print()
+
+        for func_name in func_names:
+            print("Benchmarking " + func_name + ":")
+            func = DlightBench.workloads[model_name][func_name]
+            mod = IRModule.from_expr(func)
+            for pass_ in passes:
+                print("Applying pass:", pass_)
+            with tvm.transform.PassContext(opt_level=3):
+                mod = tvm.transform.Sequential(passes)(mod)
+            benchmark_prim_func(
+                mod,
+                dym_var_sample_func=sample_func,
+                sample_num=sample_num_per_func,
+                target=target,
+                prim_func_name=func_name,
+                evaluator_config=evaluator_config,
+                rpc_config=rpc_config,
+                drop_cols=["Weight", "WxTime(ms)", "Std(us)", "PrimFunc"],
+            )
+            print()

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,61 @@
+from typing import Dict
+
+import tvm
+import tvm.dlight as dl
+
+from dlight_bench import DlightBench
+
+
+def factorized(factor: int, minimum: int):
+    def sample_dym_var_sequential(
+        dym_vars: Dict[str, str], sample_idx: int, _: int
+    ) -> Dict[str, int]:
+        """
+        Sequential dynamic shape variable sample function.
+        Sample a sequential value for each dynamic shape variable.
+
+        Parameters
+        ----------
+        vars : Dict[str, str]
+            Dynamic shape variable dictionary, e.g., {"n": "int32", "m": "int32"}
+        sample_idx : int
+            Sample index denotes the index the function is called for the same
+            dynamic shape variable dictionary & function.
+        sample_num : int
+            Sample number denotes the total number of samples.
+
+        Returns
+        -------
+        result : Dict[str, int]
+            Dynamic shape variable sample, e.g., {"n": 64, "m": 128}
+        """
+        results = {}
+        cnt = 1
+        for var in dym_vars:
+            if dym_vars[var] in ["int32", "int64"]:
+                results[var] = 2 ** (sample_idx // cnt % factor + minimum)
+            else:
+                raise TypeError(
+                    "Unsupported dynamic shape variable type: " + dym_vars[var]
+                )
+            cnt *= factor
+        return results
+
+    return sample_dym_var_sequential
+
+
+with tvm.target.Target("nvidia/geforce-rtx-3070"):
+    DlightBench.benchmark(
+        "vicuna_v1_7b_fp16",
+        func_name="matmul",
+        passes=[tvm.tir.transform.DefaultGPUSchedule()],
+        sample_func=factorized(5, 5),
+        sample_num_per_func=10,
+    )
+    DlightBench.benchmark(
+        "vicuna_v1_7b_fp16",
+        func_name="matmul",
+        passes=[dl.ApplyDefaultSchedule(dl.gpu.Fallback())],
+        sample_func=factorized(5, 5),
+        sample_num_per_func=10,
+    )

--- a/demo.py
+++ b/demo.py
@@ -56,10 +56,17 @@ with tvm.target.Target("nvidia/geforce-rtx-3070"):
         sample_func=factorized(5, 5),
         sample_num_per_func=10,
     )
-    # DlightBench.benchmark(
-    #     "vicuna_v1_7b_fp16",
-    #     category="Fallback",
-    #     passes=[dl.ApplyDefaultSchedule(dl.gpu.Fallback())],
-    #     sample_func=factorized(5, 5),
-    #     sample_num_per_func=10,
-    # )
+    DlightBench.benchmark(
+        "vicuna_v1_7b_fp16",
+        category="Fallback",
+        passes=[dl.ApplyDefaultSchedule(dl.gpu.Fallback())],
+        sample_func=factorized(5, 5),
+        sample_num_per_func=10,
+    )
+    DlightBench.benchmark(
+        "llama_2_7b_chat_hf_q4f16_1",
+        category="GEMV",
+        passes=[dl.ApplyDefaultSchedule(dl.gpu.GEMV())],
+        sample_func=factorized(5, 5),
+        sample_num_per_func=10,
+    )

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+from .vicuna_v1_7b_fp16 import *

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,5 @@
 from .vicuna_v1_7b_fp16 import *
+from .llama_2_7b_chat_hf_q4f16_0 import *
+from .llama_2_7b_chat_hf_q4f16_1 import *
+from .llama_2_13b_chat_hf_q4f16_1 import *
+from .llama_2_13b_chat_hf_q4f16_0 import *

--- a/models/llama_2_13b_chat_hf_q4f16_1.py
+++ b/models/llama_2_13b_chat_hf_q4f16_1.py
@@ -1,0 +1,721 @@
+# Please save this file to dlight_bench/models and add
+# `from .llama_2_13b_chat_hf_q4f16_1 import *` to dlight_bench/models/__init__.py
+from dlight_bench import DlightBench
+from tvm.script import tir as T
+
+
+
+@T.prim_func
+def reshape(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n), "int32")
+    T_reshape = T.match_buffer(var_T_reshape, (n,), "int32")
+    # with T.block("root"):
+    for ax0 in range(n):
+        with T.block("T_reshape"):
+            v_ax0 = T.axis.spatial(n, ax0)
+            T.reads(A[T.int64(0), v_ax0 % n])
+            T.writes(T_reshape[v_ax0])
+            T_reshape[v_ax0] = A[T.int64(0), v_ax0 % n]
+
+
+@T.prim_func
+def fused_fused_decode1_take(lv: T.Buffer((32000, 640), "uint32"), lv1: T.Buffer((32000, 160), "float16"), p_lv: T.handle, p_output0: T.handle):
+    T.func_attr({"global_symbol": "fused_fused_decode1_take", "tir.noalias": T.bool(True)})
+    n = T.int32()
+    lv_1 = T.match_buffer(p_lv, (n,), "int32")
+    var_T_take_intermediate = T.match_buffer(p_output0, (n, 5120), "float16")
+    # with T.block("root"):
+    for ax0, ax1 in T.grid(n, 5120):
+        with T.block("T_take"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(lv[lv_1[v_ax0], v_ax1 // 8], lv_1[v_ax0], lv1[lv_1[v_ax0], v_ax1 // 32])
+            T.writes(var_T_take_intermediate[v_ax0, v_ax1])
+            var_T_take_intermediate[v_ax0, v_ax1] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv[lv_1[v_ax0], v_ax1 // 8], T.Cast("uint32", v_ax1 % 8) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv1[lv_1[v_ax0], v_ax1 // 32]
+
+
+@T.prim_func
+def reshape1(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape1", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (n, T.int64(5120)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(5120)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(5120)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[(v_ax2 // T.int64(5120) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(5120)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[(v_ax2 // T.int64(5120) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(5120)]
+
+
+@T.prim_func
+def fused_fused_decode2_NT_matmul(lv3: T.Buffer((T.int64(15360), T.int64(640)), "uint32"), lv4: T.Buffer((T.int64(15360), T.int64(160)), "float16"), p_lv: T.handle, p_output0: T.handle):
+    T.func_attr({"global_symbol": "fused_fused_decode2_NT_matmul", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    lv = T.match_buffer(p_lv, (T.int64(1), n, T.int64(5120)), "float16")
+    var_NT_matmul_intermediate = T.match_buffer(p_output0, (T.int64(1), n, T.int64(15360)), "float16")
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(15360), T.int64(5120)), "float16")
+    for i, j in T.grid(T.int64(15360), T.int64(5120)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv3[v_i, v_j // T.int64(8)], lv4[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv3[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv4[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(15360), T.int64(5120)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv[v_i0, v_i1, v_k], p_output0_intermediate[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv[v_i0, v_i1, v_k] * p_output0_intermediate[v_i2, v_k]
+
+
+@T.prim_func
+def split(var_A: T.handle, var_T_split: T.handle, var_T_split_1: T.handle, var_T_split_2: T.handle):
+    T.func_attr({"global_symbol": "split", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(15360)), "float16")
+    T_split = T.match_buffer(var_T_split, (T.int64(1), n, T.int64(5120)), "float16")
+    T_split_1 = T.match_buffer(var_T_split_1, (T.int64(1), n, T.int64(5120)), "float16")
+    T_split_2 = T.match_buffer(var_T_split_2, (T.int64(1), n, T.int64(5120)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(5120)):
+        with T.block("T_split"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2])
+            T.writes(T_split[v_ax0, v_ax1, v_ax2])
+            T_split[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(5120)):
+        with T.block("T_split_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2 + T.int64(5120)])
+            T.writes(T_split_1[v_ax0, v_ax1, v_ax2])
+            T_split_1[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2 + T.int64(5120)]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(5120)):
+        with T.block("T_split_2"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2 + T.int64(10240)])
+            T.writes(T_split_2[v_ax0, v_ax1, v_ax2])
+            T_split_2[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2 + T.int64(10240)]
+
+
+@T.prim_func
+def reshape2(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape2", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(5120)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(40), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), n, T.int64(40), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[T.int64(0), ((v_ax2 * T.int64(128) + v_ax3) // T.int64(5120) + v_ax0 * n + v_ax1) % n, (v_ax2 * T.int64(128) + v_ax3) % T.int64(5120)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[T.int64(0), ((v_ax2 * T.int64(128) + v_ax3) // T.int64(5120) + v_ax0 * n + v_ax1) % n, (v_ax2 * T.int64(128) + v_ax3) % T.int64(5120)]
+
+
+@T.prim_func
+def rotary_embedding(var_A: T.handle, B: T.Buffer((T.int64(2048), T.int64(128)), "float16"), C: T.Buffer((T.int64(2048), T.int64(128)), "float16"), var_rotary: T.handle, m: T.int64):
+    T.func_attr({"global_symbol": "rotary_embedding", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(40), T.int64(128)), "float16")
+    rotary = T.match_buffer(var_rotary, (T.int64(1), n, T.int64(40), T.int64(128)), "float16")
+    # with T.block("root"):
+    for i0, i1, i2, i3 in T.grid(T.int64(1), n, T.int64(40), T.int64(128)):
+        with T.block("rotary"):
+            v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+            T.reads(B[m + v_i1 - n, v_i3], A[v_i0, v_i1, v_i2, v_i3 - T.int64(64):v_i3 - T.int64(64) + T.int64(129)], C[m + v_i1 - n, v_i3])
+            T.writes(rotary[v_i0, v_i1, v_i2, v_i3])
+            rotary[v_i0, v_i1, v_i2, v_i3] = B[m + v_i1 - n, v_i3] * A[v_i0, v_i1, v_i2, v_i3] + C[m + v_i1 - n, v_i3] * T.Select(T.int64(64) <= v_i3, A[v_i0, v_i1, v_i2, v_i3 - T.int64(64)], A[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float16(-1))
+
+
+@T.prim_func
+def squeeze(var_A: T.handle, var_T_squeeze: T.handle):
+    T.func_attr({"global_symbol": "squeeze", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(40), T.int64(128)), "float16")
+    T_squeeze = T.match_buffer(var_T_squeeze, (n, T.int64(40), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(n, T.int64(40), T.int64(128)):
+        with T.block("T_squeeze"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), v_ax0, v_ax1, v_ax2])
+            T.writes(T_squeeze[v_ax0, v_ax1, v_ax2])
+            T_squeeze[v_ax0, v_ax1, v_ax2] = A[T.int64(0), v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def reshape3(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape3", "tir.noalias": T.bool(True)})
+    m = T.int64()
+    A = T.match_buffer(var_A, (m, T.int64(40), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), m, T.int64(40), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), m, T.int64(40), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[((v_ax3 // T.int64(128) + v_ax2) // T.int64(40) + v_ax0 * m + v_ax1) % m, (v_ax3 // T.int64(128) + v_ax2) % T.int64(40), v_ax3 % T.int64(128)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[((v_ax3 // T.int64(128) + v_ax2) // T.int64(40) + v_ax0 * m + v_ax1) % m, (v_ax3 // T.int64(128) + v_ax2) % T.int64(40), v_ax3 % T.int64(128)]
+
+
+@T.prim_func
+def reshape4(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape4", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(40), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(5120)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(5120)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), (v_ax2 // T.int64(5120) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(5120) // T.int64(128), v_ax2 % T.int64(128)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[T.int64(0), (v_ax2 // T.int64(5120) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(5120) // T.int64(128), v_ax2 % T.int64(128)]
+
+
+@T.prim_func
+def fused_fused_decode3_fused_NT_matmul1_add(lv6: T.Buffer((T.int64(5120), T.int64(640)), "uint32"), lv7: T.Buffer((T.int64(5120), T.int64(160)), "float16"), p_lv41: T.handle, p_lv2: T.handle, p_output0: T.handle):
+    T.func_attr({"global_symbol": "fused_fused_decode3_fused_NT_matmul1_add", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    lv41 = T.match_buffer(p_lv41, (T.int64(1), n, T.int64(5120)), "float16")
+    lv2 = T.match_buffer(p_lv2, (T.int64(1), n, T.int64(5120)), "float16")
+    p_output0_intermediate = T.match_buffer(p_output0, (T.int64(1), n, T.int64(5120)), "float16")
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer((T.int64(5120), T.int64(5120)), "float16")
+    var_NT_matmul_intermediate = T.alloc_buffer((T.int64(1), n, T.int64(5120)), "float16")
+    for i, j in T.grid(T.int64(5120), T.int64(5120)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv6[v_i, v_j // T.int64(8)], lv7[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv6[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv7[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(5120), T.int64(5120)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv41[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv41[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(5120)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv2[v_ax0, v_ax1, v_ax2], var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2])
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = lv2[v_ax0, v_ax1, v_ax2] + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def fused_fused_decode4_NT_matmul2(lv10: T.Buffer((T.int64(27648), T.int64(640)), "uint32"), lv11: T.Buffer((T.int64(27648), T.int64(160)), "float16"), p_lv1: T.handle, p_output0: T.handle):
+    T.func_attr({"global_symbol": "fused_fused_decode4_NT_matmul2", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    lv1 = T.match_buffer(p_lv1, (T.int64(1), n, T.int64(5120)), "float16")
+    var_NT_matmul_intermediate = T.match_buffer(p_output0, (T.int64(1), n, T.int64(27648)), "float16")
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(27648), T.int64(5120)), "float16")
+    for i, j in T.grid(T.int64(27648), T.int64(5120)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv10[v_i, v_j // T.int64(8)], lv11[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv10[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv11[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(27648), T.int64(5120)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1[v_i0, v_i1, v_k], p_output0_intermediate[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv1[v_i0, v_i1, v_k] * p_output0_intermediate[v_i2, v_k]
+
+
+@T.prim_func
+def fused_split1_silu_multiply(p_lv2: T.handle, p_output0: T.handle):
+    T.func_attr({"global_symbol": "fused_split1_silu_multiply", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    lv2 = T.match_buffer(p_lv2, (T.int64(1), n, T.int64(27648)), "float16")
+    var_T_multiply_intermediate = T.match_buffer(p_output0, (T.int64(1), n, T.int64(13824)), "float16")
+    # with T.block("root"):
+    var_T_split_sections_intermediate = T.alloc_buffer((T.int64(1), n, T.int64(13824)), "float16")
+    var_T_split_sections_intermediate_1 = T.alloc_buffer((T.int64(1), n, T.int64(13824)), "float16")
+    compute = T.alloc_buffer((T.int64(1), n, T.int64(13824)), "float16")
+    var_T_multiply_intermediate_1 = T.alloc_buffer((T.int64(1), n, T.int64(13824)), "float16")
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(13824)):
+        with T.block("T_split_sections"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv2[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2] = lv2[v_ax0, v_ax1, v_ax2]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(13824)):
+        with T.block("T_split_sections_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv2[v_ax0, v_ax1, v_ax2 + T.int64(13824)])
+            T.writes(var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2] = lv2[v_ax0, v_ax1, v_ax2 + T.int64(13824)]
+    for i0, i1, i2 in T.grid(T.int64(1), n, T.int64(13824)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_T_split_sections_intermediate[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.sigmoid(var_T_split_sections_intermediate[v_i0, v_i1, v_i2])
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(13824)):
+        with T.block("T_multiply"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2], compute[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] = var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2] * compute[v_ax0, v_ax1, v_ax2]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(13824)):
+        with T.block("T_multiply_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2], var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2] = var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] * var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def fused_fused_decode5_fused_NT_matmul3_add(lv14: T.Buffer((T.int64(5120), T.int64(1728)), "uint32"), lv15: T.Buffer((T.int64(5120), T.int64(432)), "float16"), p_lv13: T.handle, p_lv9: T.handle, p_output0: T.handle):
+    T.func_attr({"global_symbol": "fused_fused_decode5_fused_NT_matmul3_add", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    lv13 = T.match_buffer(p_lv13, (T.int64(1), n, T.int64(13824)), "float16")
+    lv9 = T.match_buffer(p_lv9, (T.int64(1), n, T.int64(5120)), "float16")
+    p_output0_intermediate = T.match_buffer(p_output0, (T.int64(1), n, T.int64(5120)), "float16")
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer((T.int64(5120), T.int64(13824)), "float16")
+    var_NT_matmul_intermediate = T.alloc_buffer((T.int64(1), n, T.int64(5120)), "float16")
+    for i, j in T.grid(T.int64(5120), T.int64(13824)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv14[v_i, v_j // T.int64(8)], lv15[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv14[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv15[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(5120), T.int64(13824)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv13[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv13[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(5120)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv9[v_ax0, v_ax1, v_ax2], var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2])
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = lv9[v_ax0, v_ax1, v_ax2] + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def slice(var_A: T.handle, slice_1: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16")):
+    T.func_attr({"global_symbol": "slice", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(5120)), "float16")
+    # with T.block("root"):
+    for i, j, k in T.grid(T.int64(1), T.int64(1), T.int64(5120)):
+        with T.block("slice"):
+            v_i, v_j, v_k = T.axis.remap("SSS", [i, j, k])
+            T.reads(A[v_i, n - T.int64(1), v_k])
+            T.writes(slice_1[v_i, v_j, v_k])
+            slice_1[v_i, v_j, v_k] = A[v_i, n - T.int64(1), v_k]
+
+
+@T.prim_func
+def fused_fused_decode1_fused_NT_matmul4_cast(lv603: T.Buffer((T.int64(32000), T.int64(640)), "uint32"), lv604: T.Buffer((T.int64(32000), T.int64(160)), "float16"), lv2007: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), p_output0_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32")):
+    T.func_attr({"global_symbol": "fused_fused_decode1_fused_NT_matmul4_cast", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer((T.int64(32000), T.int64(5120)), "float16")
+    var_NT_matmul_intermediate = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(32000)), "float16")
+    for i, j in T.grid(T.int64(32000), T.int64(5120)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv603[v_i, v_j // T.int64(8)], lv604[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv603[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv604[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(32000), T.int64(5120)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv2007[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv2007[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            T.writes(p_output0_intermediate[v_i0, v_i1, v_i2])
+            p_output0_intermediate[v_i0, v_i1, v_i2] = T.Cast("float32", var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+
+
+@T.prim_func
+def reshape5(A: T.Buffer((T.int64(1), T.int64(1)), "int32"), T_reshape: T.Buffer((T.int64(1),), "int32")):
+    T.func_attr({"global_symbol": "reshape5", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0 in range(T.int64(1)):
+        with T.block("T_reshape"):
+            v_ax0 = T.axis.spatial(T.int64(1), ax0)
+            T.reads(A[T.int64(0), T.int64(0)])
+            T.writes(T_reshape[v_ax0])
+            T_reshape[v_ax0] = A[T.int64(0), T.int64(0)]
+
+
+@T.prim_func
+def fused_fused_decode1_take1(lv607: T.Buffer((32000, 640), "uint32"), lv608: T.Buffer((32000, 160), "float16"), lv2011: T.Buffer((1,), "int32"), var_T_take_intermediate: T.Buffer((1, 5120), "float16")):
+    T.func_attr({"global_symbol": "fused_fused_decode1_take1", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1 in T.grid(1, 5120):
+        with T.block("T_take"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(lv607[lv2011[v_ax0], v_ax1 // 8], lv2011[v_ax0], lv608[lv2011[v_ax0], v_ax1 // 32])
+            T.writes(var_T_take_intermediate[v_ax0, v_ax1])
+            var_T_take_intermediate[v_ax0, v_ax1] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv607[lv2011[v_ax0], v_ax1 // 8], T.Cast("uint32", v_ax1 % 8) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv608[lv2011[v_ax0], v_ax1 // 32]
+
+
+@T.prim_func
+def reshape6(A: T.Buffer((T.int64(1), T.int64(5120)), "float16"), T_reshape: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16")):
+    T.func_attr({"global_symbol": "reshape6", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(5120)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), v_ax2 % T.int64(5120)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[T.int64(0), v_ax2 % T.int64(5120)]
+
+
+@T.prim_func
+def fused_fused_decode2_NT_matmul5(lv610: T.Buffer((T.int64(15360), T.int64(640)), "uint32"), lv611: T.Buffer((T.int64(15360), T.int64(160)), "float16"), lv81: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), var_NT_matmul_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(15360)), "float16")):
+    T.func_attr({"global_symbol": "fused_fused_decode2_NT_matmul5", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(15360), T.int64(5120)), "float16")
+    for i, j in T.grid(T.int64(15360), T.int64(5120)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv610[v_i, v_j // T.int64(8)], lv611[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv610[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv611[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(15360), T.int64(5120)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv81[v_i0, v_i1, v_k], p_output0_intermediate[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv81[v_i0, v_i1, v_k] * p_output0_intermediate[v_i2, v_k]
+
+
+@T.prim_func
+def split_rotary(A: T.Buffer((1, 1, 15360), "float16"), cos: T.Buffer((2048, 128), "float16"), sin: T.Buffer((2048, 128), "float16"), T_split: T.Buffer((1, 1, 5120), "float16"), T_split_1: T.Buffer((1, 1, 5120), "float16"), T_split_2: T.Buffer((1, 1, 5120), "float16"), n: T.int64):
+    T.func_attr({"global_symbol": "split_rotary", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(5120)):
+        with T.block("T_split"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2], A[v_ax0, v_ax1, v_ax2 + T.int64(5120)], A[v_ax0, v_ax1, v_ax2 + T.int64(10240)])
+            T.writes(T_split[v_ax0, v_ax1, v_ax2], T_split_1[v_ax0, v_ax1, v_ax2], T_split_2[v_ax0, v_ax1, v_ax2])
+            T_split[v_ax0, v_ax1, v_ax2] = cos[n - T.int64(1), v_ax2 % T.int64(128)] * A[v_ax0, v_ax1, v_ax2] + sin[n - T.int64(1), v_ax2 % T.int64(128)] * T.Select(T.int64(64) <= v_ax2 % T.int64(128), A[v_ax0, v_ax1, v_ax2 - T.int64(64)], A[v_ax0, v_ax1, v_ax2 + T.int64(64)] * T.float16(-1))
+            T_split_1[v_ax0, v_ax1, v_ax2] = cos[n - T.int64(1), v_ax2 % T.int64(128)] * A[v_ax0, v_ax1, v_ax2 + T.int64(5120)] + sin[n - T.int64(1), v_ax2 % T.int64(128)] * T.Select(T.int64(64) <= v_ax2 % T.int64(128), A[v_ax0, v_ax1, v_ax2 + T.int64(5120) - T.int64(64)], A[v_ax0, v_ax1, v_ax2 + T.int64(5120) + T.int64(64)] * T.float16(-1))
+            T_split_2[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2 + T.int64(10240)]
+
+
+@T.prim_func
+def fused_reshape7(lv_0: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), var_T_reshape_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(40), T.int64(128)), "float16")):
+    T.func_attr({"global_symbol": "fused_reshape7", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(40), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(lv_0[T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(5120)])
+            T.writes(var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv_0[T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(5120)]
+
+
+@T.prim_func
+def fused_reshape7_squeeze1(lv_1: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), var_T_squeeze_intermediate: T.Buffer((T.int64(1), T.int64(40), T.int64(128)), "float16")):
+    T.func_attr({"global_symbol": "fused_reshape7_squeeze1", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    var_T_reshape_intermediate = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(40), T.int64(128)), "float16")
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(40), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(lv_1[T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(5120)])
+            T.writes(var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv_1[T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(5120)]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(40), T.int64(128)):
+        with T.block("T_squeeze"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_reshape_intermediate[T.int64(0), v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_squeeze_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_squeeze_intermediate[v_ax0, v_ax1, v_ax2] = var_T_reshape_intermediate[T.int64(0), v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def reshape3(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape3", "tir.noalias": T.bool(True)})
+    m = T.int64()
+    A = T.match_buffer(var_A, (m, T.int64(40), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), m, T.int64(40), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), m, T.int64(40), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[((v_ax3 // T.int64(128) + v_ax2) // T.int64(40) + v_ax0 * m + v_ax1) % m, (v_ax3 // T.int64(128) + v_ax2) % T.int64(40), v_ax3 % T.int64(128)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[((v_ax3 // T.int64(128) + v_ax2) // T.int64(40) + v_ax0 * m + v_ax1) % m, (v_ax3 // T.int64(128) + v_ax2) % T.int64(40), v_ax3 % T.int64(128)]
+
+
+@T.prim_func
+def reshape8(A: T.Buffer((T.int64(1), T.int64(1), T.int64(40), T.int64(128)), "float16"), T_reshape: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16")):
+    T.func_attr({"global_symbol": "reshape8", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(5120)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), T.int64(0), v_ax2 % T.int64(5120) // T.int64(128), v_ax2 % T.int64(128)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[T.int64(0), T.int64(0), v_ax2 % T.int64(5120) // T.int64(128), v_ax2 % T.int64(128)]
+
+
+@T.prim_func
+def fused_fused_decode3_fused_NT_matmul6_add1(lv619: T.Buffer((T.int64(5120), T.int64(640)), "uint32"), lv620: T.Buffer((T.int64(5120), T.int64(160)), "float16"), lv2050: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), lv2013: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), p_output0_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16")):
+    T.func_attr({"global_symbol": "fused_fused_decode3_fused_NT_matmul6_add1", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer((T.int64(5120), T.int64(5120)), "float16")
+    var_NT_matmul_intermediate = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16")
+    for i, j in T.grid(T.int64(5120), T.int64(5120)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv619[v_i, v_j // T.int64(8)], lv620[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv619[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv620[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(5120), T.int64(5120)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv2050[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv2050[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(5120)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv2013[v_ax0, v_ax1, v_ax2], var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2])
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = lv2013[v_ax0, v_ax1, v_ax2] + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def fused_fused_decode4_NT_matmul7(lv623: T.Buffer((T.int64(27648), T.int64(640)), "uint32"), lv624: T.Buffer((T.int64(27648), T.int64(160)), "float16"), lv82: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), var_NT_matmul_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(27648)), "float16")):
+    T.func_attr({"global_symbol": "fused_fused_decode4_NT_matmul7", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(27648), T.int64(5120)), "float16")
+    for i, j in T.grid(T.int64(27648), T.int64(5120)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv623[v_i, v_j // T.int64(8)], lv624[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv623[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv624[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(27648), T.int64(5120)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv82[v_i0, v_i1, v_k], p_output0_intermediate[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv82[v_i0, v_i1, v_k] * p_output0_intermediate[v_i2, v_k]
+
+
+@T.prim_func
+def fused_split2_silu1_multiply1(lv163: T.Buffer((T.int64(1), T.int64(1), T.int64(27648)), "float16"), var_T_multiply_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(13824)), "float16")):
+    T.func_attr({"global_symbol": "fused_split2_silu1_multiply1", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    var_T_split_sections_intermediate = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(13824)), "float16")
+    var_T_split_sections_intermediate_1 = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(13824)), "float16")
+    compute = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(13824)), "float16")
+    var_T_multiply_intermediate_1 = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(13824)), "float16")
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(13824)):
+        with T.block("T_split_sections"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv163[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2] = lv163[v_ax0, v_ax1, v_ax2]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(13824)):
+        with T.block("T_split_sections_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv163[v_ax0, v_ax1, v_ax2 + T.int64(13824)])
+            T.writes(var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2] = lv163[v_ax0, v_ax1, v_ax2 + T.int64(13824)]
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(13824)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_T_split_sections_intermediate[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.sigmoid(var_T_split_sections_intermediate[v_i0, v_i1, v_i2])
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(13824)):
+        with T.block("T_multiply"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2], compute[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] = var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2] * compute[v_ax0, v_ax1, v_ax2]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(13824)):
+        with T.block("T_multiply_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2], var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2] = var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] * var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def fused_fused_decode5_fused_NT_matmul8_add1(lv627: T.Buffer((T.int64(5120), T.int64(1728)), "uint32"), lv628: T.Buffer((T.int64(5120), T.int64(432)), "float16"), lv626: T.Buffer((T.int64(1), T.int64(1), T.int64(13824)), "float16"), lv622: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), p_output0_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16")):
+    T.func_attr({"global_symbol": "fused_fused_decode5_fused_NT_matmul8_add1", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer((T.int64(5120), T.int64(13824)), "float16")
+    var_NT_matmul_intermediate = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16")
+    for i, j in T.grid(T.int64(5120), T.int64(13824)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv627[v_i, v_j // T.int64(8)], lv628[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv627[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv628[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(5120), T.int64(13824)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv626[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv626[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(5120)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv622[v_ax0, v_ax1, v_ax2], var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2])
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = lv622[v_ax0, v_ax1, v_ax2] + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def slice1(A: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), slice: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16")):
+    T.func_attr({"global_symbol": "slice1", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for i, j, k in T.grid(T.int64(1), T.int64(1), T.int64(5120)):
+        with T.block("slice"):
+            v_i, v_j, v_k = T.axis.remap("SSS", [i, j, k])
+            T.reads(A[v_i, T.int64(0), v_k])
+            T.writes(slice[v_i, v_j, v_k])
+            slice[v_i, v_j, v_k] = A[v_i, T.int64(0), v_k]
+
+
+@T.prim_func
+def fused_fused_decode1_fused_NT_matmul4_cast(lv603: T.Buffer((T.int64(32000), T.int64(640)), "uint32"), lv604: T.Buffer((T.int64(32000), T.int64(160)), "float16"), lv2007: T.Buffer((T.int64(1), T.int64(1), T.int64(5120)), "float16"), p_output0_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32")):
+    T.func_attr({"global_symbol": "fused_fused_decode1_fused_NT_matmul4_cast", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer((T.int64(32000), T.int64(5120)), "float16")
+    var_NT_matmul_intermediate = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(32000)), "float16")
+    for i, j in T.grid(T.int64(32000), T.int64(5120)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv603[v_i, v_j // T.int64(8)], lv604[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (T.Cast("float16", T.bitwise_and(T.shift_right(lv603[v_i, v_j // T.int64(8)], T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4)), T.uint32(15))) - T.float16(7)) * lv604[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(32000), T.int64(5120)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv2007[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = var_NT_matmul_intermediate[v_i0, v_i1, v_i2] + lv2007[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            T.writes(p_output0_intermediate[v_i0, v_i1, v_i2])
+            p_output0_intermediate[v_i0, v_i1, v_i2] = T.Cast("float32", var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+
+
+@T.prim_func
+def divide(A: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"), B: T.Buffer((), "float32"), T_divide: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32")):
+    T.func_attr({"global_symbol": "divide", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_divide"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2], B[()])
+            T.writes(T_divide[v_ax0, v_ax1, v_ax2])
+            T_divide[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2] / B[()]
+
+
+@T.prim_func
+def softmax(A: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"), T_softmax_norm: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32")):
+    T.func_attr({"global_symbol": "softmax", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    T_softmax_maxelem = T.alloc_buffer((T.int64(1), T.int64(1)))
+    T_softmax_exp = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(32000)))
+    T_softmax_expsum = T.alloc_buffer((T.int64(1), T.int64(1)))
+    for i0, i1, k in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_maxelem"):
+            v_i0, v_i1, v_k = T.axis.remap("SSR", [i0, i1, k])
+            T.reads(A[v_i0, v_i1, v_k])
+            T.writes(T_softmax_maxelem[v_i0, v_i1])
+            with T.init():
+                T_softmax_maxelem[v_i0, v_i1] = T.float32(-3.4028234663852886e+38)
+            T_softmax_maxelem[v_i0, v_i1] = T.max(T_softmax_maxelem[v_i0, v_i1], A[v_i0, v_i1, v_k])
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_exp"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(A[v_i0, v_i1, v_i2], T_softmax_maxelem[v_i0, v_i1])
+            T.writes(T_softmax_exp[v_i0, v_i1, v_i2])
+            T_softmax_exp[v_i0, v_i1, v_i2] = T.exp(A[v_i0, v_i1, v_i2] - T_softmax_maxelem[v_i0, v_i1])
+    for i0, i1, k in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_expsum"):
+            v_i0, v_i1, v_k = T.axis.remap("SSR", [i0, i1, k])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_k])
+            T.writes(T_softmax_expsum[v_i0, v_i1])
+            with T.init():
+                T_softmax_expsum[v_i0, v_i1] = T.float32(0)
+            T_softmax_expsum[v_i0, v_i1] = T_softmax_expsum[v_i0, v_i1] + T_softmax_exp[v_i0, v_i1, v_k]
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_norm"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_i2], T_softmax_expsum[v_i0, v_i1])
+            T.writes(T_softmax_norm[v_i0, v_i1, v_i2])
+            T.block_attr({"axis": 2})
+            T_softmax_norm[v_i0, v_i1, v_i2] = T_softmax_exp[v_i0, v_i1, v_i2] / T_softmax_expsum[v_i0, v_i1]
+
+DlightBench.register_bench_workload(reshape, 'llama_2_13b_chat_hf_q4f16_1', 'reshape')
+DlightBench.register_bench_workload(fused_fused_decode1_take, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode1_take')
+DlightBench.register_bench_workload(reshape1, 'llama_2_13b_chat_hf_q4f16_1', 'reshape1')
+DlightBench.register_bench_workload(fused_fused_decode2_NT_matmul, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode2_NT_matmul')
+DlightBench.register_bench_workload(split, 'llama_2_13b_chat_hf_q4f16_1', 'split')
+DlightBench.register_bench_workload(reshape2, 'llama_2_13b_chat_hf_q4f16_1', 'reshape2')
+DlightBench.register_bench_workload(rotary_embedding, 'llama_2_13b_chat_hf_q4f16_1', 'rotary_embedding')
+DlightBench.register_bench_workload(squeeze, 'llama_2_13b_chat_hf_q4f16_1', 'squeeze')
+DlightBench.register_bench_workload(reshape3, 'llama_2_13b_chat_hf_q4f16_1', 'reshape3')
+DlightBench.register_bench_workload(reshape4, 'llama_2_13b_chat_hf_q4f16_1', 'reshape4')
+DlightBench.register_bench_workload(fused_fused_decode3_fused_NT_matmul1_add, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode3_fused_NT_matmul1_add')
+DlightBench.register_bench_workload(fused_fused_decode4_NT_matmul2, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode4_NT_matmul2')
+DlightBench.register_bench_workload(fused_split1_silu_multiply, 'llama_2_13b_chat_hf_q4f16_1', 'fused_split1_silu_multiply')
+DlightBench.register_bench_workload(fused_fused_decode5_fused_NT_matmul3_add, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode5_fused_NT_matmul3_add')
+DlightBench.register_bench_workload(slice, 'llama_2_13b_chat_hf_q4f16_1', 'slice')
+DlightBench.register_bench_workload(fused_fused_decode1_fused_NT_matmul4_cast, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode1_fused_NT_matmul4_cast')
+DlightBench.register_bench_workload(reshape5, 'llama_2_13b_chat_hf_q4f16_1', 'reshape5')
+DlightBench.register_bench_workload(fused_fused_decode1_take1, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode1_take1')
+DlightBench.register_bench_workload(reshape6, 'llama_2_13b_chat_hf_q4f16_1', 'reshape6')
+DlightBench.register_bench_workload(fused_fused_decode2_NT_matmul5, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode2_NT_matmul5')
+DlightBench.register_bench_workload(split_rotary, 'llama_2_13b_chat_hf_q4f16_1', 'split_rotary')
+DlightBench.register_bench_workload(fused_reshape7, 'llama_2_13b_chat_hf_q4f16_1', 'fused_reshape7')
+DlightBench.register_bench_workload(fused_reshape7_squeeze1, 'llama_2_13b_chat_hf_q4f16_1', 'fused_reshape7_squeeze1')
+DlightBench.register_bench_workload(reshape3, 'llama_2_13b_chat_hf_q4f16_1', 'reshape3')
+DlightBench.register_bench_workload(reshape8, 'llama_2_13b_chat_hf_q4f16_1', 'reshape8')
+DlightBench.register_bench_workload(fused_fused_decode3_fused_NT_matmul6_add1, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode3_fused_NT_matmul6_add1')
+DlightBench.register_bench_workload(fused_fused_decode4_NT_matmul7, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode4_NT_matmul7')
+DlightBench.register_bench_workload(fused_split2_silu1_multiply1, 'llama_2_13b_chat_hf_q4f16_1', 'fused_split2_silu1_multiply1')
+DlightBench.register_bench_workload(fused_fused_decode5_fused_NT_matmul8_add1, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode5_fused_NT_matmul8_add1')
+DlightBench.register_bench_workload(slice1, 'llama_2_13b_chat_hf_q4f16_1', 'slice1')
+DlightBench.register_bench_workload(fused_fused_decode1_fused_NT_matmul4_cast, 'llama_2_13b_chat_hf_q4f16_1', 'fused_fused_decode1_fused_NT_matmul4_cast')
+DlightBench.register_bench_workload(divide, 'llama_2_13b_chat_hf_q4f16_1', 'divide')
+DlightBench.register_bench_workload(softmax, 'llama_2_13b_chat_hf_q4f16_1', 'softmax')

--- a/models/llama_2_7b_chat_hf_q4f16_0.py
+++ b/models/llama_2_7b_chat_hf_q4f16_0.py
@@ -1,0 +1,1435 @@
+# Please save this file to dlight_bench/models and add
+# `from .llama_2_7b_chat_hf_q4f16_0 import *` to dlight_bench/models/__init__.py
+from dlight_bench import DlightBench
+from tvm.script import tir as T
+
+
+@T.prim_func
+def reshape(
+    A: T.Buffer((T.int64(1), T.int64(1)), "int32"),
+    T_reshape: T.Buffer((T.int64(1),), "int32"),
+):
+    T.func_attr({"global_symbol": "reshape", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0 in range(T.int64(1)):
+        with T.block("T_reshape"):
+            v_ax0 = T.axis.spatial(T.int64(1), ax0)
+            T.reads(A[T.int64(0), T.int64(0)])
+            T.writes(T_reshape[v_ax0])
+            T_reshape[v_ax0] = A[T.int64(0), T.int64(0)]
+
+
+@T.prim_func
+def fused_fused_decode1_take(
+    lv: T.Buffer((32000, 512), "uint32"),
+    lv1: T.Buffer((32000, 128), "float16"),
+    lv1611: T.Buffer((1,), "int32"),
+    var_T_take_intermediate: T.Buffer((1, 4096), "float16"),
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode1_take", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    for ax0, ax1 in T.grid(1, 4096):
+        with T.block("T_take"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(
+                lv[lv1611[v_ax0], v_ax1 // 8],
+                lv1611[v_ax0],
+                lv1[lv1611[v_ax0], v_ax1 // 32],
+            )
+            T.writes(var_T_take_intermediate[v_ax0, v_ax1])
+            var_T_take_intermediate[v_ax0, v_ax1] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv[lv1611[v_ax0], v_ax1 // 8],
+                            T.Cast("uint32", v_ax1 % 8) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv1[lv1611[v_ax0], v_ax1 // 32]
+
+
+@T.prim_func
+def reshape1(
+    A: T.Buffer((T.int64(1), T.int64(4096)), "float16"),
+    T_reshape: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "reshape1", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), v_ax2 % T.int64(4096)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[T.int64(0), v_ax2 % T.int64(4096)]
+
+
+@T.prim_func
+def fused_fused_decode7_matmul2(
+    lv3: T.Buffer((T.int64(512), T.int64(12288)), "uint32"),
+    lv4: T.Buffer((T.int64(128), T.int64(12288)), "float16"),
+    lv: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    var_matmul_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(12288)), "float16"
+    ),
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode7_matmul2", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(4096), T.int64(12288)), "float16")
+    for i, j in T.grid(T.int64(4096), T.int64(12288)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv3[v_i // T.int64(8), v_j], lv4[v_i // T.int64(32), v_j])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv3[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv4[v_i // T.int64(32), v_j]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(12288), T.int64(4096)):
+        with T.block("matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv[v_i0, v_i1, v_k], p_output0_intermediate[v_k, v_i2])
+            T.writes(var_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv[v_i0, v_i1, v_k] * p_output0_intermediate[v_k, v_i2]
+            )
+
+
+@T.prim_func
+def split_rotary(
+    A: T.Buffer((1, 1, 12288), "float16"),
+    cos: T.Buffer((2048, 128), "float16"),
+    sin: T.Buffer((2048, 128), "float16"),
+    T_split: T.Buffer((1, 1, 4096), "float16"),
+    T_split_1: T.Buffer((1, 1, 4096), "float16"),
+    T_split_2: T.Buffer((1, 1, 4096), "float16"),
+    n: T.int64,
+):
+    T.func_attr({"global_symbol": "split_rotary", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_split"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                A[v_ax0, v_ax1, v_ax2],
+                A[v_ax0, v_ax1, v_ax2 + T.int64(4096)],
+                A[v_ax0, v_ax1, v_ax2 + T.int64(8192)],
+            )
+            T.writes(
+                T_split[v_ax0, v_ax1, v_ax2],
+                T_split_1[v_ax0, v_ax1, v_ax2],
+                T_split_2[v_ax0, v_ax1, v_ax2],
+            )
+            T_split[v_ax0, v_ax1, v_ax2] = cos[
+                n - T.int64(1), v_ax2 % T.int64(128)
+            ] * A[v_ax0, v_ax1, v_ax2] + sin[
+                n - T.int64(1), v_ax2 % T.int64(128)
+            ] * T.Select(
+                T.int64(64) <= v_ax2 % T.int64(128),
+                A[v_ax0, v_ax1, v_ax2 - T.int64(64)],
+                A[v_ax0, v_ax1, v_ax2 + T.int64(64)] * T.float16(-1),
+            )
+            T_split_1[v_ax0, v_ax1, v_ax2] = cos[
+                n - T.int64(1), v_ax2 % T.int64(128)
+            ] * A[v_ax0, v_ax1, v_ax2 + T.int64(4096)] + sin[
+                n - T.int64(1), v_ax2 % T.int64(128)
+            ] * T.Select(
+                T.int64(64) <= v_ax2 % T.int64(128),
+                A[v_ax0, v_ax1, v_ax2 + T.int64(4096) - T.int64(64)],
+                A[v_ax0, v_ax1, v_ax2 + T.int64(4096) + T.int64(64)] * T.float16(-1),
+            )
+            T_split_2[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2 + T.int64(8192)]
+
+
+@T.prim_func
+def fused_reshape2(
+    lv_0: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    var_T_reshape_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"
+    ),
+):
+    T.func_attr({"global_symbol": "fused_reshape2", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                lv_0[
+                    T.int64(0),
+                    T.int64(0),
+                    (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096),
+                ]
+            )
+            T.writes(var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv_0[
+                T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)
+            ]
+
+
+@T.prim_func
+def fused_reshape2_squeeze(
+    lv_1: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    var_T_squeeze_intermediate: T.Buffer(
+        (T.int64(1), T.int64(32), T.int64(128)), "float16"
+    ),
+):
+    T.func_attr(
+        {"global_symbol": "fused_reshape2_squeeze", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    var_T_reshape_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"
+    )
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                lv_1[
+                    T.int64(0),
+                    T.int64(0),
+                    (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096),
+                ]
+            )
+            T.writes(var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv_1[
+                T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)
+            ]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_squeeze"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_reshape_intermediate[T.int64(0), v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_squeeze_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_squeeze_intermediate[
+                v_ax0, v_ax1, v_ax2
+            ] = var_T_reshape_intermediate[T.int64(0), v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def reshape3(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape3", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (n, T.int64(32), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(
+        var_T_reshape, (T.int64(1), n, T.int64(32), T.int64(128)), "float16"
+    )
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), n, T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                A[
+                    ((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * n + v_ax1)
+                    % n,
+                    (v_ax3 // T.int64(128) + v_ax2) % T.int64(32),
+                    v_ax3 % T.int64(128),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[
+                ((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * n + v_ax1)
+                % n,
+                (v_ax3 // T.int64(128) + v_ax2) % T.int64(32),
+                v_ax3 % T.int64(128),
+            ]
+
+
+@T.prim_func
+def reshape4(
+    A: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"),
+    T_reshape: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "reshape4", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                A[
+                    T.int64(0),
+                    T.int64(0),
+                    v_ax2 % T.int64(4096) // T.int64(128),
+                    v_ax2 % T.int64(128),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[
+                T.int64(0),
+                T.int64(0),
+                v_ax2 % T.int64(4096) // T.int64(128),
+                v_ax2 % T.int64(128),
+            ]
+
+
+@T.prim_func
+def fused_fused_decode8_fused_matmul3_add(
+    lv12: T.Buffer((T.int64(512), T.int64(4096)), "uint32"),
+    lv13: T.Buffer((T.int64(128), T.int64(4096)), "float16"),
+    lv1650: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    lv1613: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    p_output0_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(4096)), "float16"
+    ),
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode8_fused_matmul3_add",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer((T.int64(4096), T.int64(4096)), "float16")
+    var_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(4096)), "float16"
+    )
+    for i, j in T.grid(T.int64(4096), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv12[v_i // T.int64(8), v_j], lv13[v_i // T.int64(32), v_j])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv12[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv13[v_i // T.int64(32), v_j]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(4096), T.int64(4096)):
+        with T.block("matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1650[v_i0, v_i1, v_k], p_output0_intermediate_1[v_k, v_i2])
+            T.writes(var_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv1650[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_k, v_i2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                lv1613[v_ax0, v_ax1, v_ax2],
+                var_matmul_intermediate[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = (
+                lv1613[v_ax0, v_ax1, v_ax2]
+                + var_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def fused_fused_decode9_matmul4(
+    lv16: T.Buffer((T.int64(512), T.int64(22016)), "uint32"),
+    lv17: T.Buffer((T.int64(128), T.int64(22016)), "float16"),
+    lv1: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    var_matmul_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(22016)), "float16"
+    ),
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode9_matmul4", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(4096), T.int64(22016)), "float16")
+    for i, j in T.grid(T.int64(4096), T.int64(22016)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv16[v_i // T.int64(8), v_j], lv17[v_i // T.int64(32), v_j])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv16[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv17[v_i // T.int64(32), v_j]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(22016), T.int64(4096)):
+        with T.block("matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1[v_i0, v_i1, v_k], p_output0_intermediate[v_k, v_i2])
+            T.writes(var_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv1[v_i0, v_i1, v_k] * p_output0_intermediate[v_k, v_i2]
+            )
+
+
+@T.prim_func
+def fused_split_silu_multiply(
+    lv1656: T.Buffer((T.int64(1), T.int64(1), T.int64(22016)), "float16"),
+    var_T_multiply_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(11008)), "float16"
+    ),
+):
+    T.func_attr(
+        {"global_symbol": "fused_split_silu_multiply", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    var_T_split_sections_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(11008)), "float16"
+    )
+    var_T_split_sections_intermediate_1 = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(11008)), "float16"
+    )
+    compute = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(11008)), "float16")
+    var_T_multiply_intermediate_1 = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(11008)), "float16"
+    )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_split_sections"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv1656[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2] = lv1656[
+                v_ax0, v_ax1, v_ax2
+            ]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_split_sections_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv1656[v_ax0, v_ax1, v_ax2 + T.int64(11008)])
+            T.writes(var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2] = lv1656[
+                v_ax0, v_ax1, v_ax2 + T.int64(11008)
+            ]
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_T_split_sections_intermediate[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.sigmoid(
+                var_T_split_sections_intermediate[v_i0, v_i1, v_i2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_multiply"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2],
+                compute[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] = (
+                var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2]
+                * compute[v_ax0, v_ax1, v_ax2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_multiply_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2],
+                var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2] = (
+                var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2]
+                * var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def fused_fused_decode10_fused_matmul5_add(
+    lv20: T.Buffer((T.int64(1376), T.int64(4096)), "uint32"),
+    lv21: T.Buffer((T.int64(344), T.int64(4096)), "float16"),
+    lv19: T.Buffer((T.int64(1), T.int64(1), T.int64(11008)), "float16"),
+    lv15: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    p_output0_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(4096)), "float16"
+    ),
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode10_fused_matmul5_add",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer(
+        (T.int64(11008), T.int64(4096)), "float16"
+    )
+    var_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(4096)), "float16"
+    )
+    for i, j in T.grid(T.int64(11008), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv20[v_i // T.int64(8), v_j], lv21[v_i // T.int64(32), v_j])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv20[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv21[v_i // T.int64(32), v_j]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(4096), T.int64(11008)):
+        with T.block("matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv19[v_i0, v_i1, v_k], p_output0_intermediate_1[v_k, v_i2])
+            T.writes(var_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv19[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_k, v_i2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                lv15[v_ax0, v_ax1, v_ax2], var_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+            )
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = (
+                lv15[v_ax0, v_ax1, v_ax2] + var_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def slice1(
+    A: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    slice: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "slice1", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for i, j, k in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("slice"):
+            v_i, v_j, v_k = T.axis.remap("SSS", [i, j, k])
+            T.reads(A[v_i, T.int64(0), v_k])
+            T.writes(slice[v_i, v_j, v_k])
+            slice[v_i, v_j, v_k] = A[v_i, T.int64(0), v_k]
+
+
+@T.prim_func
+def fused_fused_decode11_fused_matmul6_cast(
+    lv1162: T.Buffer((T.int64(512), T.int64(32000)), "uint32"),
+    lv1163: T.Buffer((T.int64(128), T.int64(32000)), "float16"),
+    lv1607: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    p_output0_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(32000)), "float32"
+    ),
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode11_fused_matmul6_cast",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer(
+        (T.int64(4096), T.int64(32000)), "float16"
+    )
+    var_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(32000)), "float16"
+    )
+    for i, j in T.grid(T.int64(4096), T.int64(32000)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv1162[v_i // T.int64(8), v_j], lv1163[v_i // T.int64(32), v_j])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv1162[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv1163[v_i // T.int64(32), v_j]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(32000), T.int64(4096)):
+        with T.block("matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1607[v_i0, v_i1, v_k], p_output0_intermediate_1[v_k, v_i2])
+            T.writes(var_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv1607[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_k, v_i2]
+            )
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_matmul_intermediate[v_i0, v_i1, v_i2])
+            T.writes(p_output0_intermediate[v_i0, v_i1, v_i2])
+            p_output0_intermediate[v_i0, v_i1, v_i2] = T.Cast(
+                "float32", var_matmul_intermediate[v_i0, v_i1, v_i2]
+            )
+
+
+@T.prim_func
+def divide(
+    A: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"),
+    B: T.Buffer((), "float32"),
+    T_divide: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"),
+):
+    T.func_attr({"global_symbol": "divide", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_divide"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2], B[()])
+            T.writes(T_divide[v_ax0, v_ax1, v_ax2])
+            T_divide[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2] / B[()]
+
+
+@T.prim_func
+def softmax(
+    A: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"),
+    T_softmax_norm: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"),
+):
+    T.func_attr({"global_symbol": "softmax", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    T_softmax_maxelem = T.alloc_buffer((T.int64(1), T.int64(1)))
+    T_softmax_exp = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(32000)))
+    T_softmax_expsum = T.alloc_buffer((T.int64(1), T.int64(1)))
+    for i0, i1, k in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_maxelem"):
+            v_i0, v_i1, v_k = T.axis.remap("SSR", [i0, i1, k])
+            T.reads(A[v_i0, v_i1, v_k])
+            T.writes(T_softmax_maxelem[v_i0, v_i1])
+            with T.init():
+                T_softmax_maxelem[v_i0, v_i1] = T.float32(-3.4028234663852886e38)
+            T_softmax_maxelem[v_i0, v_i1] = T.max(
+                T_softmax_maxelem[v_i0, v_i1], A[v_i0, v_i1, v_k]
+            )
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_exp"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(A[v_i0, v_i1, v_i2], T_softmax_maxelem[v_i0, v_i1])
+            T.writes(T_softmax_exp[v_i0, v_i1, v_i2])
+            T_softmax_exp[v_i0, v_i1, v_i2] = T.exp(
+                A[v_i0, v_i1, v_i2] - T_softmax_maxelem[v_i0, v_i1]
+            )
+    for i0, i1, k in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_expsum"):
+            v_i0, v_i1, v_k = T.axis.remap("SSR", [i0, i1, k])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_k])
+            T.writes(T_softmax_expsum[v_i0, v_i1])
+            with T.init():
+                T_softmax_expsum[v_i0, v_i1] = T.float32(0)
+            T_softmax_expsum[v_i0, v_i1] = (
+                T_softmax_expsum[v_i0, v_i1] + T_softmax_exp[v_i0, v_i1, v_k]
+            )
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_norm"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_i2], T_softmax_expsum[v_i0, v_i1])
+            T.writes(T_softmax_norm[v_i0, v_i1, v_i2])
+            T.block_attr({"axis": 2})
+            T_softmax_norm[v_i0, v_i1, v_i2] = (
+                T_softmax_exp[v_i0, v_i1, v_i2] / T_softmax_expsum[v_i0, v_i1]
+            )
+
+
+@T.prim_func
+def reshape5(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape5", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n), "int32")
+    T_reshape = T.match_buffer(var_T_reshape, (n,), "int32")
+    # with T.block("root"):
+    for ax0 in range(n):
+        with T.block("T_reshape"):
+            v_ax0 = T.axis.spatial(n, ax0)
+            T.reads(A[T.int64(0), v_ax0 % n])
+            T.writes(T_reshape[v_ax0])
+            T_reshape[v_ax0] = A[T.int64(0), v_ax0 % n]
+
+
+@T.prim_func
+def fused_fused_decode1_take1(
+    lv679: T.Buffer((32000, 512), "uint32"),
+    lv680: T.Buffer((32000, 128), "float16"),
+    p_lv: T.handle,
+    p_output0: T.handle,
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode1_take1", "tir.noalias": T.bool(True)}
+    )
+    n = T.int32()
+    lv = T.match_buffer(p_lv, (n,), "int32")
+    var_T_take_intermediate = T.match_buffer(p_output0, (n, 4096), "float16")
+    # with T.block("root"):
+    for ax0, ax1 in T.grid(n, 4096):
+        with T.block("T_take"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(
+                lv679[lv[v_ax0], v_ax1 // 8], lv[v_ax0], lv680[lv[v_ax0], v_ax1 // 32]
+            )
+            T.writes(var_T_take_intermediate[v_ax0, v_ax1])
+            var_T_take_intermediate[v_ax0, v_ax1] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv679[lv[v_ax0], v_ax1 // 8],
+                            T.Cast("uint32", v_ax1 % 8) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv680[lv[v_ax0], v_ax1 // 32]
+
+
+@T.prim_func
+def reshape6(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape6", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (n, T.int64(4096)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                A[
+                    (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n,
+                    v_ax2 % T.int64(4096),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[
+                (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(4096)
+            ]
+
+
+@T.prim_func
+def fused_decode2(
+    params_2: T.Buffer((T.int64(512), T.int64(12288)), "uint32"),
+    params_3: T.Buffer((T.int64(128), T.int64(12288)), "float16"),
+    var_T_transpose_intermediate: T.Buffer((T.int64(12288), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "fused_decode2", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    decode = T.alloc_buffer((T.int64(4096), T.int64(12288)), "float16")
+    for i, j in T.grid(T.int64(4096), T.int64(12288)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(params_2[v_i // T.int64(8), v_j], params_3[v_i // T.int64(32), v_j])
+            T.writes(decode[v_i, v_j])
+            decode[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            params_2[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * params_3[v_i // T.int64(32), v_j]
+    for ax0, ax1 in T.grid(T.int64(12288), T.int64(4096)):
+        with T.block("T_transpose"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(decode[v_ax1, v_ax0])
+            T.writes(var_T_transpose_intermediate[v_ax0, v_ax1])
+            var_T_transpose_intermediate[v_ax0, v_ax1] = decode[v_ax1, v_ax0]
+
+
+@T.prim_func
+def NT_matmul(
+    var_A: T.handle,
+    B: T.Buffer((T.int64(12288), T.int64(4096)), "float16"),
+    var_NT_matmul: T.handle,
+):
+    T.func_attr({"global_symbol": "NT_matmul", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(4096)), "float16")
+    NT_matmul_1 = T.match_buffer(
+        var_NT_matmul, (T.int64(1), n, T.int64(12288)), "float16"
+    )
+    # with T.block("root"):
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(12288), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(A[v_i0, v_i1, v_k], B[v_i2, v_k])
+            T.writes(NT_matmul_1[v_i0, v_i1, v_i2])
+            with T.init():
+                NT_matmul_1[v_i0, v_i1, v_i2] = T.float16(0)
+            NT_matmul_1[v_i0, v_i1, v_i2] = (
+                NT_matmul_1[v_i0, v_i1, v_i2] + A[v_i0, v_i1, v_k] * B[v_i2, v_k]
+            )
+
+
+@T.prim_func
+def split1(
+    var_A: T.handle,
+    var_T_split: T.handle,
+    var_T_split_1: T.handle,
+    var_T_split_2: T.handle,
+):
+    T.func_attr({"global_symbol": "split1", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(12288)), "float16")
+    T_split = T.match_buffer(var_T_split, (T.int64(1), n, T.int64(4096)), "float16")
+    T_split_1 = T.match_buffer(var_T_split_1, (T.int64(1), n, T.int64(4096)), "float16")
+    T_split_2 = T.match_buffer(var_T_split_2, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_split"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2])
+            T.writes(T_split[v_ax0, v_ax1, v_ax2])
+            T_split[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_split_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2 + T.int64(4096)])
+            T.writes(T_split_1[v_ax0, v_ax1, v_ax2])
+            T_split_1[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2 + T.int64(4096)]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_split_2"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2 + T.int64(8192)])
+            T.writes(T_split_2[v_ax0, v_ax1, v_ax2])
+            T_split_2[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2 + T.int64(8192)]
+
+
+@T.prim_func
+def reshape7(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape7", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(4096)), "float16")
+    T_reshape = T.match_buffer(
+        var_T_reshape, (T.int64(1), n, T.int64(32), T.int64(128)), "float16"
+    )
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), n, T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                A[
+                    T.int64(0),
+                    (
+                        (v_ax2 * T.int64(128) + v_ax3) // T.int64(4096)
+                        + v_ax0 * n
+                        + v_ax1
+                    )
+                    % n,
+                    (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[
+                T.int64(0),
+                ((v_ax2 * T.int64(128) + v_ax3) // T.int64(4096) + v_ax0 * n + v_ax1)
+                % n,
+                (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096),
+            ]
+
+
+@T.prim_func
+def rotary_embedding(
+    var_A: T.handle,
+    B: T.Buffer((T.int64(2048), T.int64(128)), "float16"),
+    C: T.Buffer((T.int64(2048), T.int64(128)), "float16"),
+    var_rotary: T.handle,
+    m: T.int64,
+):
+    T.func_attr({"global_symbol": "rotary_embedding", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    rotary = T.match_buffer(
+        var_rotary, (T.int64(1), n, T.int64(32), T.int64(128)), "float16"
+    )
+    # with T.block("root"):
+    for i0, i1, i2, i3 in T.grid(T.int64(1), n, T.int64(32), T.int64(128)):
+        with T.block("rotary"):
+            v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+            T.reads(
+                B[m + v_i1 - n, v_i3],
+                A[
+                    v_i0,
+                    v_i1,
+                    v_i2,
+                    v_i3 - T.int64(64) : v_i3 - T.int64(64) + T.int64(129),
+                ],
+                C[m + v_i1 - n, v_i3],
+            )
+            T.writes(rotary[v_i0, v_i1, v_i2, v_i3])
+            rotary[v_i0, v_i1, v_i2, v_i3] = B[m + v_i1 - n, v_i3] * A[
+                v_i0, v_i1, v_i2, v_i3
+            ] + C[m + v_i1 - n, v_i3] * T.Select(
+                T.int64(64) <= v_i3,
+                A[v_i0, v_i1, v_i2, v_i3 - T.int64(64)],
+                A[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float16(-1),
+            )
+
+
+@T.prim_func
+def squeeze1(var_A: T.handle, var_T_squeeze: T.handle):
+    T.func_attr({"global_symbol": "squeeze1", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    T_squeeze = T.match_buffer(var_T_squeeze, (n, T.int64(32), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(n, T.int64(32), T.int64(128)):
+        with T.block("T_squeeze"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), v_ax0, v_ax1, v_ax2])
+            T.writes(T_squeeze[v_ax0, v_ax1, v_ax2])
+            T_squeeze[v_ax0, v_ax1, v_ax2] = A[T.int64(0), v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def reshape3(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape3", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (n, T.int64(32), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(
+        var_T_reshape, (T.int64(1), n, T.int64(32), T.int64(128)), "float16"
+    )
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), n, T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                A[
+                    ((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * n + v_ax1)
+                    % n,
+                    (v_ax3 // T.int64(128) + v_ax2) % T.int64(32),
+                    v_ax3 % T.int64(128),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[
+                ((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * n + v_ax1)
+                % n,
+                (v_ax3 // T.int64(128) + v_ax2) % T.int64(32),
+                v_ax3 % T.int64(128),
+            ]
+
+
+@T.prim_func
+def reshape8(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape8", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                A[
+                    T.int64(0),
+                    (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n,
+                    v_ax2 % T.int64(4096) // T.int64(128),
+                    v_ax2 % T.int64(128),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[
+                T.int64(0),
+                (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n,
+                v_ax2 % T.int64(4096) // T.int64(128),
+                v_ax2 % T.int64(128),
+            ]
+
+
+@T.prim_func
+def fused_decode3(
+    params_4: T.Buffer((T.int64(512), T.int64(4096)), "uint32"),
+    params_5: T.Buffer((T.int64(128), T.int64(4096)), "float16"),
+    var_T_transpose_intermediate: T.Buffer((T.int64(4096), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "fused_decode3", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    decode = T.alloc_buffer((T.int64(4096), T.int64(4096)), "float16")
+    for i, j in T.grid(T.int64(4096), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(params_4[v_i // T.int64(8), v_j], params_5[v_i // T.int64(32), v_j])
+            T.writes(decode[v_i, v_j])
+            decode[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            params_4[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * params_5[v_i // T.int64(32), v_j]
+    for ax0, ax1 in T.grid(T.int64(4096), T.int64(4096)):
+        with T.block("T_transpose"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(decode[v_ax1, v_ax0])
+            T.writes(var_T_transpose_intermediate[v_ax0, v_ax1])
+            var_T_transpose_intermediate[v_ax0, v_ax1] = decode[v_ax1, v_ax0]
+
+
+@T.prim_func
+def fused_NT_matmul1_add1(
+    p_lv41: T.handle,
+    lv468: T.Buffer((T.int64(4096), T.int64(4096)), "float16"),
+    p_lv2: T.handle,
+    p_output0: T.handle,
+):
+    T.func_attr({"global_symbol": "fused_NT_matmul1_add1", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    lv41 = T.match_buffer(p_lv41, (T.int64(1), n, T.int64(4096)), "float16")
+    lv2 = T.match_buffer(p_lv2, (T.int64(1), n, T.int64(4096)), "float16")
+    var_T_add_intermediate = T.match_buffer(
+        p_output0, (T.int64(1), n, T.int64(4096)), "float16"
+    )
+    # with T.block("root"):
+    var_NT_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), n, T.int64(4096)), "float16"
+    )
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(4096), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv41[v_i0, v_i1, v_k], lv468[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv41[v_i0, v_i1, v_k] * lv468[v_i2, v_k]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                lv2[v_ax0, v_ax1, v_ax2],
+                var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_add_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_add_intermediate[v_ax0, v_ax1, v_ax2] = (
+                lv2[v_ax0, v_ax1, v_ax2]
+                + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def fused_decode4(
+    params_6: T.Buffer((T.int64(512), T.int64(22016)), "uint32"),
+    params_7: T.Buffer((T.int64(128), T.int64(22016)), "float16"),
+    var_T_transpose_intermediate: T.Buffer((T.int64(22016), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "fused_decode4", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    decode = T.alloc_buffer((T.int64(4096), T.int64(22016)), "float16")
+    for i, j in T.grid(T.int64(4096), T.int64(22016)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(params_6[v_i // T.int64(8), v_j], params_7[v_i // T.int64(32), v_j])
+            T.writes(decode[v_i, v_j])
+            decode[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            params_6[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * params_7[v_i // T.int64(32), v_j]
+    for ax0, ax1 in T.grid(T.int64(22016), T.int64(4096)):
+        with T.block("T_transpose"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(decode[v_ax1, v_ax0])
+            T.writes(var_T_transpose_intermediate[v_ax0, v_ax1])
+            var_T_transpose_intermediate[v_ax0, v_ax1] = decode[v_ax1, v_ax0]
+
+
+@T.prim_func
+def NT_matmul2(
+    var_A: T.handle,
+    B: T.Buffer((T.int64(22016), T.int64(4096)), "float16"),
+    var_NT_matmul: T.handle,
+):
+    T.func_attr({"global_symbol": "NT_matmul2", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(4096)), "float16")
+    NT_matmul = T.match_buffer(
+        var_NT_matmul, (T.int64(1), n, T.int64(22016)), "float16"
+    )
+    # with T.block("root"):
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(22016), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(A[v_i0, v_i1, v_k], B[v_i2, v_k])
+            T.writes(NT_matmul[v_i0, v_i1, v_i2])
+            with T.init():
+                NT_matmul[v_i0, v_i1, v_i2] = T.float16(0)
+            NT_matmul[v_i0, v_i1, v_i2] = (
+                NT_matmul[v_i0, v_i1, v_i2] + A[v_i0, v_i1, v_k] * B[v_i2, v_k]
+            )
+
+
+@T.prim_func
+def fused_split2_silu1_multiply1(p_lv2: T.handle, p_output0: T.handle):
+    T.func_attr(
+        {"global_symbol": "fused_split2_silu1_multiply1", "tir.noalias": T.bool(True)}
+    )
+    n = T.int64()
+    lv2 = T.match_buffer(p_lv2, (T.int64(1), n, T.int64(22016)), "float16")
+    var_T_multiply_intermediate = T.match_buffer(
+        p_output0, (T.int64(1), n, T.int64(11008)), "float16"
+    )
+    # with T.block("root"):
+    var_T_split_sections_intermediate = T.alloc_buffer(
+        (T.int64(1), n, T.int64(11008)), "float16"
+    )
+    var_T_split_sections_intermediate_1 = T.alloc_buffer(
+        (T.int64(1), n, T.int64(11008)), "float16"
+    )
+    compute = T.alloc_buffer((T.int64(1), n, T.int64(11008)), "float16")
+    var_T_multiply_intermediate_1 = T.alloc_buffer(
+        (T.int64(1), n, T.int64(11008)), "float16"
+    )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_split_sections"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv2[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2] = lv2[
+                v_ax0, v_ax1, v_ax2
+            ]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_split_sections_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv2[v_ax0, v_ax1, v_ax2 + T.int64(11008)])
+            T.writes(var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2] = lv2[
+                v_ax0, v_ax1, v_ax2 + T.int64(11008)
+            ]
+    for i0, i1, i2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_T_split_sections_intermediate[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.sigmoid(
+                var_T_split_sections_intermediate[v_i0, v_i1, v_i2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_multiply"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2],
+                compute[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] = (
+                var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2]
+                * compute[v_ax0, v_ax1, v_ax2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_multiply_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2],
+                var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2] = (
+                var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2]
+                * var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def fused_decode5(
+    params_8: T.Buffer((T.int64(1376), T.int64(4096)), "uint32"),
+    params_9: T.Buffer((T.int64(344), T.int64(4096)), "float16"),
+    var_T_transpose_intermediate: T.Buffer((T.int64(4096), T.int64(11008)), "float16"),
+):
+    T.func_attr({"global_symbol": "fused_decode5", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    decode = T.alloc_buffer((T.int64(11008), T.int64(4096)), "float16")
+    for i, j in T.grid(T.int64(11008), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(params_8[v_i // T.int64(8), v_j], params_9[v_i // T.int64(32), v_j])
+            T.writes(decode[v_i, v_j])
+            decode[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            params_8[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * params_9[v_i // T.int64(32), v_j]
+    for ax0, ax1 in T.grid(T.int64(4096), T.int64(11008)):
+        with T.block("T_transpose"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(decode[v_ax1, v_ax0])
+            T.writes(var_T_transpose_intermediate[v_ax0, v_ax1])
+            var_T_transpose_intermediate[v_ax0, v_ax1] = decode[v_ax1, v_ax0]
+
+
+@T.prim_func
+def fused_NT_matmul3_add1(
+    p_lv52: T.handle,
+    lv475: T.Buffer((T.int64(4096), T.int64(11008)), "float16"),
+    p_lv44: T.handle,
+    p_output0: T.handle,
+):
+    T.func_attr({"global_symbol": "fused_NT_matmul3_add1", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    lv52 = T.match_buffer(p_lv52, (T.int64(1), n, T.int64(11008)), "float16")
+    lv44 = T.match_buffer(p_lv44, (T.int64(1), n, T.int64(4096)), "float16")
+    var_T_add_intermediate = T.match_buffer(
+        p_output0, (T.int64(1), n, T.int64(4096)), "float16"
+    )
+    # with T.block("root"):
+    var_NT_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), n, T.int64(4096)), "float16"
+    )
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(4096), T.int64(11008)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv52[v_i0, v_i1, v_k], lv475[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv52[v_i0, v_i1, v_k] * lv475[v_i2, v_k]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                lv44[v_ax0, v_ax1, v_ax2],
+                var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_add_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_add_intermediate[v_ax0, v_ax1, v_ax2] = (
+                lv44[v_ax0, v_ax1, v_ax2]
+                + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def slice(
+    var_A: T.handle,
+    slice_1: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "slice", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for i, j, k in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("slice"):
+            v_i, v_j, v_k = T.axis.remap("SSS", [i, j, k])
+            T.reads(A[v_i, n - T.int64(1), v_k])
+            T.writes(slice_1[v_i, v_j, v_k])
+            slice_1[v_i, v_j, v_k] = A[v_i, n - T.int64(1), v_k]
+
+
+@T.prim_func
+def fused_fused_decode11_fused_matmul6_cast(
+    lv1162: T.Buffer((T.int64(512), T.int64(32000)), "uint32"),
+    lv1163: T.Buffer((T.int64(128), T.int64(32000)), "float16"),
+    lv1607: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    p_output0_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(32000)), "float32"
+    ),
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode11_fused_matmul6_cast",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer(
+        (T.int64(4096), T.int64(32000)), "float16"
+    )
+    var_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(32000)), "float16"
+    )
+    for i, j in T.grid(T.int64(4096), T.int64(32000)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv1162[v_i // T.int64(8), v_j], lv1163[v_i // T.int64(32), v_j])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv1162[v_i // T.int64(8), v_j],
+                            T.Cast("uint32", v_i % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv1163[v_i // T.int64(32), v_j]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(32000), T.int64(4096)):
+        with T.block("matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1607[v_i0, v_i1, v_k], p_output0_intermediate_1[v_k, v_i2])
+            T.writes(var_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv1607[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_k, v_i2]
+            )
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_matmul_intermediate[v_i0, v_i1, v_i2])
+            T.writes(p_output0_intermediate[v_i0, v_i1, v_i2])
+            p_output0_intermediate[v_i0, v_i1, v_i2] = T.Cast(
+                "float32", var_matmul_intermediate[v_i0, v_i1, v_i2]
+            )
+
+
+DlightBench.register_bench_workload(reshape, "llama_2_7b_chat_hf_q4f16_0", "reshape")
+DlightBench.register_bench_workload(
+    fused_fused_decode1_take, "llama_2_7b_chat_hf_q4f16_0", "fused_fused_decode1_take"
+)
+DlightBench.register_bench_workload(reshape1, "llama_2_7b_chat_hf_q4f16_0", "reshape1")
+DlightBench.register_bench_workload(
+    fused_fused_decode7_matmul2,
+    "llama_2_7b_chat_hf_q4f16_0",
+    "fused_fused_decode7_matmul2",
+)
+DlightBench.register_bench_workload(
+    split_rotary, "llama_2_7b_chat_hf_q4f16_0", "split_rotary"
+)
+DlightBench.register_bench_workload(
+    fused_reshape2, "llama_2_7b_chat_hf_q4f16_0", "fused_reshape2"
+)
+DlightBench.register_bench_workload(
+    fused_reshape2_squeeze, "llama_2_7b_chat_hf_q4f16_0", "fused_reshape2_squeeze"
+)
+DlightBench.register_bench_workload(reshape3, "llama_2_7b_chat_hf_q4f16_0", "reshape3")
+DlightBench.register_bench_workload(reshape4, "llama_2_7b_chat_hf_q4f16_0", "reshape4")
+DlightBench.register_bench_workload(
+    fused_fused_decode8_fused_matmul3_add,
+    "llama_2_7b_chat_hf_q4f16_0",
+    "fused_fused_decode8_fused_matmul3_add",
+)
+DlightBench.register_bench_workload(
+    fused_fused_decode9_matmul4,
+    "llama_2_7b_chat_hf_q4f16_0",
+    "fused_fused_decode9_matmul4",
+)
+DlightBench.register_bench_workload(
+    fused_split_silu_multiply, "llama_2_7b_chat_hf_q4f16_0", "fused_split_silu_multiply"
+)
+DlightBench.register_bench_workload(
+    fused_fused_decode10_fused_matmul5_add,
+    "llama_2_7b_chat_hf_q4f16_0",
+    "fused_fused_decode10_fused_matmul5_add",
+)
+DlightBench.register_bench_workload(slice1, "llama_2_7b_chat_hf_q4f16_0", "slice1")
+DlightBench.register_bench_workload(
+    fused_fused_decode11_fused_matmul6_cast,
+    "llama_2_7b_chat_hf_q4f16_0",
+    "fused_fused_decode11_fused_matmul6_cast",
+)
+DlightBench.register_bench_workload(divide, "llama_2_7b_chat_hf_q4f16_0", "divide")
+DlightBench.register_bench_workload(softmax, "llama_2_7b_chat_hf_q4f16_0", "softmax")
+DlightBench.register_bench_workload(reshape5, "llama_2_7b_chat_hf_q4f16_0", "reshape5")
+DlightBench.register_bench_workload(
+    fused_fused_decode1_take1, "llama_2_7b_chat_hf_q4f16_0", "fused_fused_decode1_take1"
+)
+DlightBench.register_bench_workload(reshape6, "llama_2_7b_chat_hf_q4f16_0", "reshape6")
+DlightBench.register_bench_workload(
+    fused_decode2, "llama_2_7b_chat_hf_q4f16_0", "fused_decode2"
+)
+DlightBench.register_bench_workload(
+    NT_matmul, "llama_2_7b_chat_hf_q4f16_0", "NT_matmul"
+)
+DlightBench.register_bench_workload(split1, "llama_2_7b_chat_hf_q4f16_0", "split1")
+DlightBench.register_bench_workload(reshape7, "llama_2_7b_chat_hf_q4f16_0", "reshape7")
+DlightBench.register_bench_workload(
+    rotary_embedding, "llama_2_7b_chat_hf_q4f16_0", "rotary_embedding"
+)
+DlightBench.register_bench_workload(squeeze1, "llama_2_7b_chat_hf_q4f16_0", "squeeze1")
+DlightBench.register_bench_workload(reshape3, "llama_2_7b_chat_hf_q4f16_0", "reshape3")
+DlightBench.register_bench_workload(reshape8, "llama_2_7b_chat_hf_q4f16_0", "reshape8")
+DlightBench.register_bench_workload(
+    fused_decode3, "llama_2_7b_chat_hf_q4f16_0", "fused_decode3"
+)
+DlightBench.register_bench_workload(
+    fused_NT_matmul1_add1, "llama_2_7b_chat_hf_q4f16_0", "fused_NT_matmul1_add1"
+)
+DlightBench.register_bench_workload(
+    fused_decode4, "llama_2_7b_chat_hf_q4f16_0", "fused_decode4"
+)
+DlightBench.register_bench_workload(
+    NT_matmul2, "llama_2_7b_chat_hf_q4f16_0", "NT_matmul2"
+)
+DlightBench.register_bench_workload(
+    fused_split2_silu1_multiply1,
+    "llama_2_7b_chat_hf_q4f16_0",
+    "fused_split2_silu1_multiply1",
+)
+DlightBench.register_bench_workload(
+    fused_decode5, "llama_2_7b_chat_hf_q4f16_0", "fused_decode5"
+)
+DlightBench.register_bench_workload(
+    fused_NT_matmul3_add1, "llama_2_7b_chat_hf_q4f16_0", "fused_NT_matmul3_add1"
+)
+DlightBench.register_bench_workload(slice, "llama_2_7b_chat_hf_q4f16_0", "slice")
+DlightBench.register_bench_workload(
+    fused_fused_decode11_fused_matmul6_cast,
+    "llama_2_7b_chat_hf_q4f16_0",
+    "fused_fused_decode11_fused_matmul6_cast",
+)

--- a/models/llama_2_7b_chat_hf_q4f16_1.py
+++ b/models/llama_2_7b_chat_hf_q4f16_1.py
@@ -1,0 +1,1393 @@
+# Please save this file to dlight_bench/models and add
+# `from .llama_2_7b_chat_hf_q4f16_1 import *` to dlight_bench/models/__init__.py
+from dlight_bench import DlightBench
+from tvm.script import tir as T
+
+
+@T.prim_func
+def reshape(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n), "int32")
+    T_reshape = T.match_buffer(var_T_reshape, (n,), "int32")
+    # with T.block("root"):
+    for ax0 in range(n):
+        with T.block("T_reshape"):
+            v_ax0 = T.axis.spatial(n, ax0)
+            T.reads(A[T.int64(0), v_ax0 % n])
+            T.writes(T_reshape[v_ax0])
+            T_reshape[v_ax0] = A[T.int64(0), v_ax0 % n]
+
+
+@T.prim_func
+def fused_fused_decode1_take(
+    lv: T.Buffer((32000, 512), "uint32"),
+    lv1: T.Buffer((32000, 128), "float16"),
+    p_lv: T.handle,
+    p_output0: T.handle,
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode1_take", "tir.noalias": T.bool(True)}
+    )
+    n = T.int32()
+    lv_1 = T.match_buffer(p_lv, (n,), "int32")
+    var_T_take_intermediate = T.match_buffer(p_output0, (n, 4096), "float16")
+    # with T.block("root"):
+    for ax0, ax1 in T.grid(n, 4096):
+        with T.block("T_take"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(
+                lv[lv_1[v_ax0], v_ax1 // 8], lv_1[v_ax0], lv1[lv_1[v_ax0], v_ax1 // 32]
+            )
+            T.writes(var_T_take_intermediate[v_ax0, v_ax1])
+            var_T_take_intermediate[v_ax0, v_ax1] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv[lv_1[v_ax0], v_ax1 // 8],
+                            T.Cast("uint32", v_ax1 % 8) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv1[lv_1[v_ax0], v_ax1 // 32]
+
+
+@T.prim_func
+def reshape1(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape1", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (n, T.int64(4096)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                A[
+                    (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n,
+                    v_ax2 % T.int64(4096),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[
+                (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(4096)
+            ]
+
+
+@T.prim_func
+def fused_fused_decode2_NT_matmul(
+    lv3: T.Buffer((T.int64(12288), T.int64(512)), "uint32"),
+    lv4: T.Buffer((T.int64(12288), T.int64(128)), "float16"),
+    p_lv: T.handle,
+    p_output0: T.handle,
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode2_NT_matmul", "tir.noalias": T.bool(True)}
+    )
+    n = T.int64()
+    lv = T.match_buffer(p_lv, (T.int64(1), n, T.int64(4096)), "float16")
+    var_NT_matmul_intermediate = T.match_buffer(
+        p_output0, (T.int64(1), n, T.int64(12288)), "float16"
+    )
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(12288), T.int64(4096)), "float16")
+    for i, j in T.grid(T.int64(12288), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv3[v_i, v_j // T.int64(8)], lv4[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv3[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv4[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(12288), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv[v_i0, v_i1, v_k], p_output0_intermediate[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv[v_i0, v_i1, v_k] * p_output0_intermediate[v_i2, v_k]
+            )
+
+
+@T.prim_func
+def split(
+    var_A: T.handle,
+    var_T_split: T.handle,
+    var_T_split_1: T.handle,
+    var_T_split_2: T.handle,
+):
+    T.func_attr({"global_symbol": "split", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(12288)), "float16")
+    T_split = T.match_buffer(var_T_split, (T.int64(1), n, T.int64(4096)), "float16")
+    T_split_1 = T.match_buffer(var_T_split_1, (T.int64(1), n, T.int64(4096)), "float16")
+    T_split_2 = T.match_buffer(var_T_split_2, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_split"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2])
+            T.writes(T_split[v_ax0, v_ax1, v_ax2])
+            T_split[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_split_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2 + T.int64(4096)])
+            T.writes(T_split_1[v_ax0, v_ax1, v_ax2])
+            T_split_1[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2 + T.int64(4096)]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_split_2"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2 + T.int64(8192)])
+            T.writes(T_split_2[v_ax0, v_ax1, v_ax2])
+            T_split_2[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2 + T.int64(8192)]
+
+
+@T.prim_func
+def reshape2(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape2", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(4096)), "float16")
+    T_reshape = T.match_buffer(
+        var_T_reshape, (T.int64(1), n, T.int64(32), T.int64(128)), "float16"
+    )
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), n, T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                A[
+                    T.int64(0),
+                    (
+                        (v_ax2 * T.int64(128) + v_ax3) // T.int64(4096)
+                        + v_ax0 * n
+                        + v_ax1
+                    )
+                    % n,
+                    (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[
+                T.int64(0),
+                ((v_ax2 * T.int64(128) + v_ax3) // T.int64(4096) + v_ax0 * n + v_ax1)
+                % n,
+                (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096),
+            ]
+
+
+@T.prim_func
+def rotary_embedding(
+    var_A: T.handle,
+    B: T.Buffer((T.int64(2048), T.int64(128)), "float16"),
+    C: T.Buffer((T.int64(2048), T.int64(128)), "float16"),
+    var_rotary: T.handle,
+    m: T.int64,
+):
+    T.func_attr({"global_symbol": "rotary_embedding", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    rotary = T.match_buffer(
+        var_rotary, (T.int64(1), n, T.int64(32), T.int64(128)), "float16"
+    )
+    # with T.block("root"):
+    for i0, i1, i2, i3 in T.grid(T.int64(1), n, T.int64(32), T.int64(128)):
+        with T.block("rotary"):
+            v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+            T.reads(
+                B[m + v_i1 - n, v_i3],
+                A[
+                    v_i0,
+                    v_i1,
+                    v_i2,
+                    v_i3 - T.int64(64) : v_i3 - T.int64(64) + T.int64(129),
+                ],
+                C[m + v_i1 - n, v_i3],
+            )
+            T.writes(rotary[v_i0, v_i1, v_i2, v_i3])
+            rotary[v_i0, v_i1, v_i2, v_i3] = B[m + v_i1 - n, v_i3] * A[
+                v_i0, v_i1, v_i2, v_i3
+            ] + C[m + v_i1 - n, v_i3] * T.Select(
+                T.int64(64) <= v_i3,
+                A[v_i0, v_i1, v_i2, v_i3 - T.int64(64)],
+                A[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float16(-1),
+            )
+
+
+@T.prim_func
+def squeeze(var_A: T.handle, var_T_squeeze: T.handle):
+    T.func_attr({"global_symbol": "squeeze", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    T_squeeze = T.match_buffer(var_T_squeeze, (n, T.int64(32), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(n, T.int64(32), T.int64(128)):
+        with T.block("T_squeeze"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), v_ax0, v_ax1, v_ax2])
+            T.writes(T_squeeze[v_ax0, v_ax1, v_ax2])
+            T_squeeze[v_ax0, v_ax1, v_ax2] = A[T.int64(0), v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def reshape3(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape3", "tir.noalias": T.bool(True)})
+    m = T.int64()
+    A = T.match_buffer(var_A, (m, T.int64(32), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(
+        var_T_reshape, (T.int64(1), m, T.int64(32), T.int64(128)), "float16"
+    )
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), m, T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                A[
+                    ((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * m + v_ax1)
+                    % m,
+                    (v_ax3 // T.int64(128) + v_ax2) % T.int64(32),
+                    v_ax3 % T.int64(128),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[
+                ((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * m + v_ax1)
+                % m,
+                (v_ax3 // T.int64(128) + v_ax2) % T.int64(32),
+                v_ax3 % T.int64(128),
+            ]
+
+
+@T.prim_func
+def reshape4(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape4", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                A[
+                    T.int64(0),
+                    (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n,
+                    v_ax2 % T.int64(4096) // T.int64(128),
+                    v_ax2 % T.int64(128),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[
+                T.int64(0),
+                (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n,
+                v_ax2 % T.int64(4096) // T.int64(128),
+                v_ax2 % T.int64(128),
+            ]
+
+
+@T.prim_func
+def fused_fused_decode3_fused_NT_matmul1_add(
+    lv6: T.Buffer((T.int64(4096), T.int64(512)), "uint32"),
+    lv7: T.Buffer((T.int64(4096), T.int64(128)), "float16"),
+    p_lv41: T.handle,
+    p_lv2: T.handle,
+    p_output0: T.handle,
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode3_fused_NT_matmul1_add",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    n = T.int64()
+    lv41 = T.match_buffer(p_lv41, (T.int64(1), n, T.int64(4096)), "float16")
+    lv2 = T.match_buffer(p_lv2, (T.int64(1), n, T.int64(4096)), "float16")
+    p_output0_intermediate = T.match_buffer(
+        p_output0, (T.int64(1), n, T.int64(4096)), "float16"
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer((T.int64(4096), T.int64(4096)), "float16")
+    var_NT_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), n, T.int64(4096)), "float16"
+    )
+    for i, j in T.grid(T.int64(4096), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv6[v_i, v_j // T.int64(8)], lv7[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv6[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv7[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(4096), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv41[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv41[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                lv2[v_ax0, v_ax1, v_ax2],
+                var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = (
+                lv2[v_ax0, v_ax1, v_ax2]
+                + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def fused_fused_decode4_NT_matmul2(
+    lv10: T.Buffer((T.int64(22016), T.int64(512)), "uint32"),
+    lv11: T.Buffer((T.int64(22016), T.int64(128)), "float16"),
+    p_lv1: T.handle,
+    p_output0: T.handle,
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode4_NT_matmul2", "tir.noalias": T.bool(True)}
+    )
+    n = T.int64()
+    lv1 = T.match_buffer(p_lv1, (T.int64(1), n, T.int64(4096)), "float16")
+    var_NT_matmul_intermediate = T.match_buffer(
+        p_output0, (T.int64(1), n, T.int64(22016)), "float16"
+    )
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(22016), T.int64(4096)), "float16")
+    for i, j in T.grid(T.int64(22016), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv10[v_i, v_j // T.int64(8)], lv11[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv10[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv11[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(22016), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1[v_i0, v_i1, v_k], p_output0_intermediate[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv1[v_i0, v_i1, v_k] * p_output0_intermediate[v_i2, v_k]
+            )
+
+
+@T.prim_func
+def fused_split1_silu_multiply(p_lv2: T.handle, p_output0: T.handle):
+    T.func_attr(
+        {"global_symbol": "fused_split1_silu_multiply", "tir.noalias": T.bool(True)}
+    )
+    n = T.int64()
+    lv2 = T.match_buffer(p_lv2, (T.int64(1), n, T.int64(22016)), "float16")
+    var_T_multiply_intermediate = T.match_buffer(
+        p_output0, (T.int64(1), n, T.int64(11008)), "float16"
+    )
+    # with T.block("root"):
+    var_T_split_sections_intermediate = T.alloc_buffer(
+        (T.int64(1), n, T.int64(11008)), "float16"
+    )
+    var_T_split_sections_intermediate_1 = T.alloc_buffer(
+        (T.int64(1), n, T.int64(11008)), "float16"
+    )
+    compute = T.alloc_buffer((T.int64(1), n, T.int64(11008)), "float16")
+    var_T_multiply_intermediate_1 = T.alloc_buffer(
+        (T.int64(1), n, T.int64(11008)), "float16"
+    )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_split_sections"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv2[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2] = lv2[
+                v_ax0, v_ax1, v_ax2
+            ]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_split_sections_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv2[v_ax0, v_ax1, v_ax2 + T.int64(11008)])
+            T.writes(var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2] = lv2[
+                v_ax0, v_ax1, v_ax2 + T.int64(11008)
+            ]
+    for i0, i1, i2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_T_split_sections_intermediate[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.sigmoid(
+                var_T_split_sections_intermediate[v_i0, v_i1, v_i2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_multiply"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2],
+                compute[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] = (
+                var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2]
+                * compute[v_ax0, v_ax1, v_ax2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_multiply_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2],
+                var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2] = (
+                var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2]
+                * var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def fused_fused_decode5_fused_NT_matmul3_add(
+    lv14: T.Buffer((T.int64(4096), T.int64(1376)), "uint32"),
+    lv15: T.Buffer((T.int64(4096), T.int64(344)), "float16"),
+    p_lv13: T.handle,
+    p_lv9: T.handle,
+    p_output0: T.handle,
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode5_fused_NT_matmul3_add",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    n = T.int64()
+    lv13 = T.match_buffer(p_lv13, (T.int64(1), n, T.int64(11008)), "float16")
+    lv9 = T.match_buffer(p_lv9, (T.int64(1), n, T.int64(4096)), "float16")
+    p_output0_intermediate = T.match_buffer(
+        p_output0, (T.int64(1), n, T.int64(4096)), "float16"
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer(
+        (T.int64(4096), T.int64(11008)), "float16"
+    )
+    var_NT_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), n, T.int64(4096)), "float16"
+    )
+    for i, j in T.grid(T.int64(4096), T.int64(11008)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv14[v_i, v_j // T.int64(8)], lv15[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv14[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv15[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), n, T.int64(4096), T.int64(11008)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv13[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv13[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                lv9[v_ax0, v_ax1, v_ax2],
+                var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = (
+                lv9[v_ax0, v_ax1, v_ax2]
+                + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def slice(
+    var_A: T.handle,
+    slice_1: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "slice", "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for i, j, k in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("slice"):
+            v_i, v_j, v_k = T.axis.remap("SSS", [i, j, k])
+            T.reads(A[v_i, n - T.int64(1), v_k])
+            T.writes(slice_1[v_i, v_j, v_k])
+            slice_1[v_i, v_j, v_k] = A[v_i, n - T.int64(1), v_k]
+
+
+@T.prim_func
+def fused_fused_decode1_fused_NT_matmul4_cast(
+    lv483: T.Buffer((T.int64(32000), T.int64(512)), "uint32"),
+    lv484: T.Buffer((T.int64(32000), T.int64(128)), "float16"),
+    lv1607: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    p_output0_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(32000)), "float32"
+    ),
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode1_fused_NT_matmul4_cast",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer(
+        (T.int64(32000), T.int64(4096)), "float16"
+    )
+    var_NT_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(32000)), "float16"
+    )
+    for i, j in T.grid(T.int64(32000), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv483[v_i, v_j // T.int64(8)], lv484[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv483[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv484[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(32000), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1607[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv1607[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+            )
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            T.writes(p_output0_intermediate[v_i0, v_i1, v_i2])
+            p_output0_intermediate[v_i0, v_i1, v_i2] = T.Cast(
+                "float32", var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+            )
+
+
+@T.prim_func
+def reshape5(
+    A: T.Buffer((T.int64(1), T.int64(1)), "int32"),
+    T_reshape: T.Buffer((T.int64(1),), "int32"),
+):
+    T.func_attr({"global_symbol": "reshape5", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0 in range(T.int64(1)):
+        with T.block("T_reshape"):
+            v_ax0 = T.axis.spatial(T.int64(1), ax0)
+            T.reads(A[T.int64(0), T.int64(0)])
+            T.writes(T_reshape[v_ax0])
+            T_reshape[v_ax0] = A[T.int64(0), T.int64(0)]
+
+
+@T.prim_func
+def fused_fused_decode1_take1(
+    lv487: T.Buffer((32000, 512), "uint32"),
+    lv488: T.Buffer((32000, 128), "float16"),
+    lv1611: T.Buffer((1,), "int32"),
+    var_T_take_intermediate: T.Buffer((1, 4096), "float16"),
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode1_take1", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    for ax0, ax1 in T.grid(1, 4096):
+        with T.block("T_take"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(
+                lv487[lv1611[v_ax0], v_ax1 // 8],
+                lv1611[v_ax0],
+                lv488[lv1611[v_ax0], v_ax1 // 32],
+            )
+            T.writes(var_T_take_intermediate[v_ax0, v_ax1])
+            var_T_take_intermediate[v_ax0, v_ax1] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv487[lv1611[v_ax0], v_ax1 // 8],
+                            T.Cast("uint32", v_ax1 % 8) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv488[lv1611[v_ax0], v_ax1 // 32]
+
+
+@T.prim_func
+def reshape6(
+    A: T.Buffer((T.int64(1), T.int64(4096)), "float16"),
+    T_reshape: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "reshape6", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), v_ax2 % T.int64(4096)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[T.int64(0), v_ax2 % T.int64(4096)]
+
+
+@T.prim_func
+def fused_fused_decode2_NT_matmul5(
+    lv490: T.Buffer((T.int64(12288), T.int64(512)), "uint32"),
+    lv491: T.Buffer((T.int64(12288), T.int64(128)), "float16"),
+    lv65: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    var_NT_matmul_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(12288)), "float16"
+    ),
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode2_NT_matmul5", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(12288), T.int64(4096)), "float16")
+    for i, j in T.grid(T.int64(12288), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv490[v_i, v_j // T.int64(8)], lv491[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv490[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv491[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(12288), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv65[v_i0, v_i1, v_k], p_output0_intermediate[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv65[v_i0, v_i1, v_k] * p_output0_intermediate[v_i2, v_k]
+            )
+
+
+@T.prim_func
+def split_rotary(
+    A: T.Buffer((1, 1, 12288), "float16"),
+    cos: T.Buffer((2048, 128), "float16"),
+    sin: T.Buffer((2048, 128), "float16"),
+    T_split: T.Buffer((1, 1, 4096), "float16"),
+    T_split_1: T.Buffer((1, 1, 4096), "float16"),
+    T_split_2: T.Buffer((1, 1, 4096), "float16"),
+    n: T.int64,
+):
+    T.func_attr({"global_symbol": "split_rotary", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_split"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                A[v_ax0, v_ax1, v_ax2],
+                A[v_ax0, v_ax1, v_ax2 + T.int64(4096)],
+                A[v_ax0, v_ax1, v_ax2 + T.int64(8192)],
+            )
+            T.writes(
+                T_split[v_ax0, v_ax1, v_ax2],
+                T_split_1[v_ax0, v_ax1, v_ax2],
+                T_split_2[v_ax0, v_ax1, v_ax2],
+            )
+            T_split[v_ax0, v_ax1, v_ax2] = cos[
+                n - T.int64(1), v_ax2 % T.int64(128)
+            ] * A[v_ax0, v_ax1, v_ax2] + sin[
+                n - T.int64(1), v_ax2 % T.int64(128)
+            ] * T.Select(
+                T.int64(64) <= v_ax2 % T.int64(128),
+                A[v_ax0, v_ax1, v_ax2 - T.int64(64)],
+                A[v_ax0, v_ax1, v_ax2 + T.int64(64)] * T.float16(-1),
+            )
+            T_split_1[v_ax0, v_ax1, v_ax2] = cos[
+                n - T.int64(1), v_ax2 % T.int64(128)
+            ] * A[v_ax0, v_ax1, v_ax2 + T.int64(4096)] + sin[
+                n - T.int64(1), v_ax2 % T.int64(128)
+            ] * T.Select(
+                T.int64(64) <= v_ax2 % T.int64(128),
+                A[v_ax0, v_ax1, v_ax2 + T.int64(4096) - T.int64(64)],
+                A[v_ax0, v_ax1, v_ax2 + T.int64(4096) + T.int64(64)] * T.float16(-1),
+            )
+            T_split_2[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2 + T.int64(8192)]
+
+
+@T.prim_func
+def fused_reshape7(
+    lv_0: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    var_T_reshape_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"
+    ),
+):
+    T.func_attr({"global_symbol": "fused_reshape7", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                lv_0[
+                    T.int64(0),
+                    T.int64(0),
+                    (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096),
+                ]
+            )
+            T.writes(var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv_0[
+                T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)
+            ]
+
+
+@T.prim_func
+def fused_reshape7_squeeze1(
+    lv_1: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    var_T_squeeze_intermediate: T.Buffer(
+        (T.int64(1), T.int64(32), T.int64(128)), "float16"
+    ),
+):
+    T.func_attr(
+        {"global_symbol": "fused_reshape7_squeeze1", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    var_T_reshape_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"
+    )
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                lv_1[
+                    T.int64(0),
+                    T.int64(0),
+                    (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096),
+                ]
+            )
+            T.writes(var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv_1[
+                T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)
+            ]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_squeeze"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_reshape_intermediate[T.int64(0), v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_squeeze_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_squeeze_intermediate[
+                v_ax0, v_ax1, v_ax2
+            ] = var_T_reshape_intermediate[T.int64(0), v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def reshape3(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"global_symbol": "reshape3", "tir.noalias": T.bool(True)})
+    m = T.int64()
+    A = T.match_buffer(var_A, (m, T.int64(32), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(
+        var_T_reshape, (T.int64(1), m, T.int64(32), T.int64(128)), "float16"
+    )
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), m, T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(
+                A[
+                    ((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * m + v_ax1)
+                    % m,
+                    (v_ax3 // T.int64(128) + v_ax2) % T.int64(32),
+                    v_ax3 % T.int64(128),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[
+                ((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * m + v_ax1)
+                % m,
+                (v_ax3 // T.int64(128) + v_ax2) % T.int64(32),
+                v_ax3 % T.int64(128),
+            ]
+
+
+@T.prim_func
+def reshape8(
+    A: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"),
+    T_reshape: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "reshape8", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                A[
+                    T.int64(0),
+                    T.int64(0),
+                    v_ax2 % T.int64(4096) // T.int64(128),
+                    v_ax2 % T.int64(128),
+                ]
+            )
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[
+                T.int64(0),
+                T.int64(0),
+                v_ax2 % T.int64(4096) // T.int64(128),
+                v_ax2 % T.int64(128),
+            ]
+
+
+@T.prim_func
+def fused_fused_decode3_fused_NT_matmul6_add1(
+    lv499: T.Buffer((T.int64(4096), T.int64(512)), "uint32"),
+    lv500: T.Buffer((T.int64(4096), T.int64(128)), "float16"),
+    lv1650: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    lv1613: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    p_output0_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(4096)), "float16"
+    ),
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode3_fused_NT_matmul6_add1",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer((T.int64(4096), T.int64(4096)), "float16")
+    var_NT_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(4096)), "float16"
+    )
+    for i, j in T.grid(T.int64(4096), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv499[v_i, v_j // T.int64(8)], lv500[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv499[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv500[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(4096), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1650[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv1650[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                lv1613[v_ax0, v_ax1, v_ax2],
+                var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = (
+                lv1613[v_ax0, v_ax1, v_ax2]
+                + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def fused_fused_decode4_NT_matmul7(
+    lv503: T.Buffer((T.int64(22016), T.int64(512)), "uint32"),
+    lv504: T.Buffer((T.int64(22016), T.int64(128)), "float16"),
+    lv66: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    var_NT_matmul_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(22016)), "float16"
+    ),
+):
+    T.func_attr(
+        {"global_symbol": "fused_fused_decode4_NT_matmul7", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    p_output0_intermediate = T.alloc_buffer((T.int64(22016), T.int64(4096)), "float16")
+    for i, j in T.grid(T.int64(22016), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv503[v_i, v_j // T.int64(8)], lv504[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate[v_i, v_j])
+            p_output0_intermediate[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv503[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv504[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(22016), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv66[v_i0, v_i1, v_k], p_output0_intermediate[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv66[v_i0, v_i1, v_k] * p_output0_intermediate[v_i2, v_k]
+            )
+
+
+@T.prim_func
+def fused_split2_silu1_multiply1(
+    lv131: T.Buffer((T.int64(1), T.int64(1), T.int64(22016)), "float16"),
+    var_T_multiply_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(11008)), "float16"
+    ),
+):
+    T.func_attr(
+        {"global_symbol": "fused_split2_silu1_multiply1", "tir.noalias": T.bool(True)}
+    )
+    # with T.block("root"):
+    var_T_split_sections_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(11008)), "float16"
+    )
+    var_T_split_sections_intermediate_1 = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(11008)), "float16"
+    )
+    compute = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(11008)), "float16")
+    var_T_multiply_intermediate_1 = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(11008)), "float16"
+    )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_split_sections"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv131[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2] = lv131[
+                v_ax0, v_ax1, v_ax2
+            ]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_split_sections_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv131[v_ax0, v_ax1, v_ax2 + T.int64(11008)])
+            T.writes(var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2] = lv131[
+                v_ax0, v_ax1, v_ax2 + T.int64(11008)
+            ]
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_T_split_sections_intermediate[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.sigmoid(
+                var_T_split_sections_intermediate[v_i0, v_i1, v_i2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_multiply"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2],
+                compute[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] = (
+                var_T_split_sections_intermediate[v_ax0, v_ax1, v_ax2]
+                * compute[v_ax0, v_ax1, v_ax2]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_multiply_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2],
+                var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2] = (
+                var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2]
+                * var_T_split_sections_intermediate_1[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def fused_fused_decode5_fused_NT_matmul8_add1(
+    lv507: T.Buffer((T.int64(4096), T.int64(1376)), "uint32"),
+    lv508: T.Buffer((T.int64(4096), T.int64(344)), "float16"),
+    lv506: T.Buffer((T.int64(1), T.int64(1), T.int64(11008)), "float16"),
+    lv502: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    p_output0_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(4096)), "float16"
+    ),
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode5_fused_NT_matmul8_add1",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer(
+        (T.int64(4096), T.int64(11008)), "float16"
+    )
+    var_NT_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(4096)), "float16"
+    )
+    for i, j in T.grid(T.int64(4096), T.int64(11008)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv507[v_i, v_j // T.int64(8)], lv508[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv507[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv508[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(4096), T.int64(11008)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv506[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv506[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+            )
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(
+                lv502[v_ax0, v_ax1, v_ax2],
+                var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2],
+            )
+            T.writes(p_output0_intermediate[v_ax0, v_ax1, v_ax2])
+            p_output0_intermediate[v_ax0, v_ax1, v_ax2] = (
+                lv502[v_ax0, v_ax1, v_ax2]
+                + var_NT_matmul_intermediate[v_ax0, v_ax1, v_ax2]
+            )
+
+
+@T.prim_func
+def slice1(
+    A: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    slice: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+):
+    T.func_attr({"global_symbol": "slice1", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for i, j, k in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("slice"):
+            v_i, v_j, v_k = T.axis.remap("SSS", [i, j, k])
+            T.reads(A[v_i, T.int64(0), v_k])
+            T.writes(slice[v_i, v_j, v_k])
+            slice[v_i, v_j, v_k] = A[v_i, T.int64(0), v_k]
+
+
+@T.prim_func
+def fused_fused_decode1_fused_NT_matmul4_cast(
+    lv483: T.Buffer((T.int64(32000), T.int64(512)), "uint32"),
+    lv484: T.Buffer((T.int64(32000), T.int64(128)), "float16"),
+    lv1607: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"),
+    p_output0_intermediate: T.Buffer(
+        (T.int64(1), T.int64(1), T.int64(32000)), "float32"
+    ),
+):
+    T.func_attr(
+        {
+            "global_symbol": "fused_fused_decode1_fused_NT_matmul4_cast",
+            "tir.noalias": T.bool(True),
+        }
+    )
+    # with T.block("root"):
+    p_output0_intermediate_1 = T.alloc_buffer(
+        (T.int64(32000), T.int64(4096)), "float16"
+    )
+    var_NT_matmul_intermediate = T.alloc_buffer(
+        (T.int64(1), T.int64(1), T.int64(32000)), "float16"
+    )
+    for i, j in T.grid(T.int64(32000), T.int64(4096)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv483[v_i, v_j // T.int64(8)], lv484[v_i, v_j // T.int64(32)])
+            T.writes(p_output0_intermediate_1[v_i, v_j])
+            p_output0_intermediate_1[v_i, v_j] = (
+                T.Cast(
+                    "float16",
+                    T.bitwise_and(
+                        T.shift_right(
+                            lv483[v_i, v_j // T.int64(8)],
+                            T.Cast("uint32", v_j % T.int64(8)) * T.uint32(4),
+                        ),
+                        T.uint32(15),
+                    ),
+                )
+                - T.float16(7)
+            ) * lv484[v_i, v_j // T.int64(32)]
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(32000), T.int64(4096)):
+        with T.block("NT_matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1607[v_i0, v_i1, v_k], p_output0_intermediate_1[v_i2, v_k])
+            T.writes(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = T.float16(0)
+            var_NT_matmul_intermediate[v_i0, v_i1, v_i2] = (
+                var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+                + lv1607[v_i0, v_i1, v_k] * p_output0_intermediate_1[v_i2, v_k]
+            )
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(var_NT_matmul_intermediate[v_i0, v_i1, v_i2])
+            T.writes(p_output0_intermediate[v_i0, v_i1, v_i2])
+            p_output0_intermediate[v_i0, v_i1, v_i2] = T.Cast(
+                "float32", var_NT_matmul_intermediate[v_i0, v_i1, v_i2]
+            )
+
+
+@T.prim_func
+def divide(
+    A: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"),
+    B: T.Buffer((), "float32"),
+    T_divide: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"),
+):
+    T.func_attr({"global_symbol": "divide", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_divide"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[v_ax0, v_ax1, v_ax2], B[()])
+            T.writes(T_divide[v_ax0, v_ax1, v_ax2])
+            T_divide[v_ax0, v_ax1, v_ax2] = A[v_ax0, v_ax1, v_ax2] / B[()]
+
+
+@T.prim_func
+def softmax(
+    A: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"),
+    T_softmax_norm: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32"),
+):
+    T.func_attr({"global_symbol": "softmax", "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    T_softmax_maxelem = T.alloc_buffer((T.int64(1), T.int64(1)))
+    T_softmax_exp = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(32000)))
+    T_softmax_expsum = T.alloc_buffer((T.int64(1), T.int64(1)))
+    for i0, i1, k in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_maxelem"):
+            v_i0, v_i1, v_k = T.axis.remap("SSR", [i0, i1, k])
+            T.reads(A[v_i0, v_i1, v_k])
+            T.writes(T_softmax_maxelem[v_i0, v_i1])
+            with T.init():
+                T_softmax_maxelem[v_i0, v_i1] = T.float32(-3.4028234663852886e38)
+            T_softmax_maxelem[v_i0, v_i1] = T.max(
+                T_softmax_maxelem[v_i0, v_i1], A[v_i0, v_i1, v_k]
+            )
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_exp"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(A[v_i0, v_i1, v_i2], T_softmax_maxelem[v_i0, v_i1])
+            T.writes(T_softmax_exp[v_i0, v_i1, v_i2])
+            T_softmax_exp[v_i0, v_i1, v_i2] = T.exp(
+                A[v_i0, v_i1, v_i2] - T_softmax_maxelem[v_i0, v_i1]
+            )
+    for i0, i1, k in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_expsum"):
+            v_i0, v_i1, v_k = T.axis.remap("SSR", [i0, i1, k])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_k])
+            T.writes(T_softmax_expsum[v_i0, v_i1])
+            with T.init():
+                T_softmax_expsum[v_i0, v_i1] = T.float32(0)
+            T_softmax_expsum[v_i0, v_i1] = (
+                T_softmax_expsum[v_i0, v_i1] + T_softmax_exp[v_i0, v_i1, v_k]
+            )
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("T_softmax_norm"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_i2], T_softmax_expsum[v_i0, v_i1])
+            T.writes(T_softmax_norm[v_i0, v_i1, v_i2])
+            T.block_attr({"axis": 2})
+            T_softmax_norm[v_i0, v_i1, v_i2] = (
+                T_softmax_exp[v_i0, v_i1, v_i2] / T_softmax_expsum[v_i0, v_i1]
+            )
+
+
+DlightBench.register_bench_workload(reshape, "llama_2_7b_chat_hf_q4f16_1", "reshape")
+DlightBench.register_bench_workload(
+    fused_fused_decode1_take, "llama_2_7b_chat_hf_q4f16_1", "fused_fused_decode1_take"
+)
+DlightBench.register_bench_workload(reshape1, "llama_2_7b_chat_hf_q4f16_1", "reshape1")
+DlightBench.register_bench_workload(
+    fused_fused_decode2_NT_matmul,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode2_NT_matmul",
+)
+DlightBench.register_bench_workload(split, "llama_2_7b_chat_hf_q4f16_1", "split")
+DlightBench.register_bench_workload(reshape2, "llama_2_7b_chat_hf_q4f16_1", "reshape2")
+DlightBench.register_bench_workload(
+    rotary_embedding, "llama_2_7b_chat_hf_q4f16_1", "rotary_embedding"
+)
+DlightBench.register_bench_workload(squeeze, "llama_2_7b_chat_hf_q4f16_1", "squeeze")
+DlightBench.register_bench_workload(reshape3, "llama_2_7b_chat_hf_q4f16_1", "reshape3")
+DlightBench.register_bench_workload(reshape4, "llama_2_7b_chat_hf_q4f16_1", "reshape4")
+DlightBench.register_bench_workload(
+    fused_fused_decode3_fused_NT_matmul1_add,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode3_fused_NT_matmul1_add",
+)
+DlightBench.register_bench_workload(
+    fused_fused_decode4_NT_matmul2,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode4_NT_matmul2",
+)
+DlightBench.register_bench_workload(
+    fused_split1_silu_multiply,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_split1_silu_multiply",
+)
+DlightBench.register_bench_workload(
+    fused_fused_decode5_fused_NT_matmul3_add,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode5_fused_NT_matmul3_add",
+)
+DlightBench.register_bench_workload(slice, "llama_2_7b_chat_hf_q4f16_1", "slice")
+DlightBench.register_bench_workload(
+    fused_fused_decode1_fused_NT_matmul4_cast,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode1_fused_NT_matmul4_cast",
+)
+DlightBench.register_bench_workload(reshape5, "llama_2_7b_chat_hf_q4f16_1", "reshape5")
+DlightBench.register_bench_workload(
+    fused_fused_decode1_take1, "llama_2_7b_chat_hf_q4f16_1", "fused_fused_decode1_take1"
+)
+DlightBench.register_bench_workload(reshape6, "llama_2_7b_chat_hf_q4f16_1", "reshape6")
+DlightBench.register_bench_workload(
+    fused_fused_decode2_NT_matmul5,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode2_NT_matmul5",
+)
+DlightBench.register_bench_workload(
+    split_rotary, "llama_2_7b_chat_hf_q4f16_1", "split_rotary"
+)
+DlightBench.register_bench_workload(
+    fused_reshape7, "llama_2_7b_chat_hf_q4f16_1", "fused_reshape7"
+)
+DlightBench.register_bench_workload(
+    fused_reshape7_squeeze1, "llama_2_7b_chat_hf_q4f16_1", "fused_reshape7_squeeze1"
+)
+DlightBench.register_bench_workload(reshape3, "llama_2_7b_chat_hf_q4f16_1", "reshape3")
+DlightBench.register_bench_workload(reshape8, "llama_2_7b_chat_hf_q4f16_1", "reshape8")
+DlightBench.register_bench_workload(
+    fused_fused_decode3_fused_NT_matmul6_add1,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode3_fused_NT_matmul6_add1",
+)
+DlightBench.register_bench_workload(
+    fused_fused_decode4_NT_matmul7,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode4_NT_matmul7",
+)
+DlightBench.register_bench_workload(
+    fused_split2_silu1_multiply1,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_split2_silu1_multiply1",
+)
+DlightBench.register_bench_workload(
+    fused_fused_decode5_fused_NT_matmul8_add1,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode5_fused_NT_matmul8_add1",
+)
+DlightBench.register_bench_workload(slice1, "llama_2_7b_chat_hf_q4f16_1", "slice1")
+DlightBench.register_bench_workload(
+    fused_fused_decode1_fused_NT_matmul4_cast,
+    "llama_2_7b_chat_hf_q4f16_1",
+    "fused_fused_decode1_fused_NT_matmul4_cast",
+)
+DlightBench.register_bench_workload(divide, "llama_2_7b_chat_hf_q4f16_1", "divide")
+DlightBench.register_bench_workload(softmax, "llama_2_7b_chat_hf_q4f16_1", "softmax")

--- a/models/vicuna_v1_7b_fp16.py
+++ b/models/vicuna_v1_7b_fp16.py
@@ -1,0 +1,708 @@
+from dlight_bench import DlightBench
+from tvm.script import tir as T
+
+
+
+@T.prim_func
+def reshape5(A: T.Buffer((T.int64(1), T.int64(1)), "int32"), T_reshape: T.Buffer((T.int64(1),), "int32")):
+    T.func_attr({"op_pattern": 1, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0 in range(T.int64(1)):
+        with T.block("T_reshape"):
+            v_ax0 = T.axis.spatial(T.int64(1), ax0)
+            T.reads(A[T.int64(0), T.int64(0)])
+            T.writes(T_reshape[v_ax0])
+            T_reshape[v_ax0] = A[T.int64(0), T.int64(0)]
+
+
+@T.prim_func
+def take1(A: T.Buffer((T.int64(32000), T.int64(4096)), "float16"), B: T.Buffer((T.int64(1),), "int32"), T_take: T.Buffer((T.int64(1), T.int64(4096)), "float16")):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1 in T.grid(T.int64(1), T.int64(4096)):
+        with T.block("T_take"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(A[B[v_ax0], v_ax1], B[v_ax0])
+            T.writes(T_take[v_ax0, v_ax1])
+            T_take[v_ax0, v_ax1] = A[B[v_ax0], v_ax1]
+
+
+@T.prim_func
+def reshape6(A: T.Buffer((T.int64(1), T.int64(4096)), "float16"), T_reshape: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16")):
+    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), v_ax2 % T.int64(4096)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[T.int64(0), v_ax2 % T.int64(4096)]
+
+
+@T.prim_func
+def full(var_T_full: T.handle):
+    T.func_attr({"op_pattern": 0, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    T_full = T.match_buffer(var_T_full, (T.int64(1), T.int64(1), T.int64(1), n), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(1), n):
+        with T.block("T_full"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads()
+            T.writes(T_full[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_full[v_ax0, v_ax1, v_ax2, v_ax3] = T.float16(0)
+
+
+@T.prim_func
+def rms_norm1(A: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"), B: T.Buffer((T.int64(4096),), "float16"), rms_norm: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16")):
+    T.func_attr({"op_pattern": 4, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    Ared_temp = T.alloc_buffer((T.int64(1), T.int64(1)))
+    for bsz, i, k in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("Ared_temp"):
+            v_bsz, v_i, v_k = T.axis.remap("SSR", [bsz, i, k])
+            T.reads(A[v_bsz, v_i, v_k])
+            T.writes(Ared_temp[v_bsz, v_i])
+            with T.init():
+                Ared_temp[v_bsz, v_i] = T.float32(0)
+            Ared_temp[v_bsz, v_i] = Ared_temp[v_bsz, v_i] + T.Cast("float32", A[v_bsz, v_i, v_k]) * T.Cast("float32", A[v_bsz, v_i, v_k])
+    for bsz, i, k in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("rms_norm"):
+            v_bsz, v_i, v_k = T.axis.remap("SSS", [bsz, i, k])
+            T.reads(B[v_k], A[v_bsz, v_i, v_k], Ared_temp[v_bsz, v_i])
+            T.writes(rms_norm[v_bsz, v_i, v_k])
+            rms_norm[v_bsz, v_i, v_k] = T.Cast("float16", T.Cast("float32", B[v_k]) * (T.Cast("float32", A[v_bsz, v_i, v_k]) / T.sqrt(Ared_temp[v_bsz, v_i] * T.float32(0.000244140625) + T.float32(9.9999999999999995e-07))))
+
+
+@T.prim_func
+def reshape7(A: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"), T_reshape: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16")):
+    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)]
+
+
+@T.prim_func
+def fused_reshape7_squeeze1(lv195: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"), var_T_squeeze_intermediate: T.Buffer((T.int64(1), T.int64(32), T.int64(128)), "float16")):
+    T.func_attr({"tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    var_T_reshape_intermediate = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16")
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(lv195[T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)])
+            T.writes(var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv195[T.int64(0), T.int64(0), (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_squeeze"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_reshape_intermediate[T.int64(0), v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_squeeze_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_squeeze_intermediate[v_ax0, v_ax1, v_ax2] = var_T_reshape_intermediate[T.int64(0), v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def rotary_embedding1(A: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"), B: T.Buffer((T.int64(2048), T.int64(128)), "float16"), C: T.Buffer((T.int64(2048), T.int64(128)), "float16"), rotary: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"), n: T.int64):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("rotary"):
+            v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+            T.reads(B[n + v_i1 - T.int64(1), v_i3], A[v_i0, v_i1, v_i2, v_i3 - T.int64(64):v_i3 - T.int64(64) + T.int64(129)], C[n + v_i1 - T.int64(1), v_i3])
+            T.writes(rotary[v_i0, v_i1, v_i2, v_i3])
+            rotary[v_i0, v_i1, v_i2, v_i3] = B[n + v_i1 - T.int64(1), v_i3] * A[v_i0, v_i1, v_i2, v_i3] + C[n + v_i1 - T.int64(1), v_i3] * T.Select(T.int64(64) <= v_i3, A[v_i0, v_i1, v_i2, v_i3 - T.int64(64)], A[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float16(-1))
+
+
+@T.prim_func
+def squeeze1(A: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"), T_squeeze: T.Buffer((T.int64(1), T.int64(32), T.int64(128)), "float16")):
+    T.func_attr({"op_pattern": 1, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_squeeze"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), v_ax0, v_ax1, v_ax2])
+            T.writes(T_squeeze[v_ax0, v_ax1, v_ax2])
+            T_squeeze[v_ax0, v_ax1, v_ax2] = A[T.int64(0), v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def reshape3(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    m = T.int64()
+    A = T.match_buffer(var_A, (m, T.int64(32), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), m, T.int64(32), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), m, T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * m + v_ax1) % m, (v_ax3 // T.int64(128) + v_ax2) % T.int64(32), v_ax3 % T.int64(128)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * m + v_ax1) % m, (v_ax3 // T.int64(128) + v_ax2) % T.int64(32), v_ax3 % T.int64(128)]
+
+
+@T.prim_func
+def transpose2(A: T.Buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16"), T_transpose: T.Buffer((T.int64(1), T.int64(32), T.int64(1), T.int64(128)), "float16")):
+    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(32), T.int64(1), T.int64(128)):
+        with T.block("T_transpose"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[v_ax0, v_ax2, v_ax1, v_ax3])
+            T.writes(T_transpose[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_transpose[v_ax0, v_ax1, v_ax2, v_ax3] = A[v_ax0, v_ax2, v_ax1, v_ax3]
+
+
+@T.prim_func
+def transpose(var_A: T.handle, var_T_transpose: T.handle):
+    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    T_transpose = T.match_buffer(var_T_transpose, (T.int64(1), T.int64(32), n, T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(32), n, T.int64(128)):
+        with T.block("T_transpose"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[v_ax0, v_ax2, v_ax1, v_ax3])
+            T.writes(T_transpose[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_transpose[v_ax0, v_ax1, v_ax2, v_ax3] = A[v_ax0, v_ax2, v_ax1, v_ax3]
+
+
+@T.prim_func
+def fused_divide1_add1(p_lv196: T.handle, p_lv1486: T.handle, p_output0: T.handle):
+    T.func_attr({"tir.noalias": T.bool(True)})
+    n = T.int64()
+    lv196 = T.match_buffer(p_lv196, (T.int64(1), T.int64(32), T.int64(1), n), "float16")
+    lv1486 = T.match_buffer(p_lv1486, (T.int64(1), T.int64(1), T.int64(1), n), "float16")
+    var_T_add_intermediate = T.match_buffer(p_output0, (T.int64(1), T.int64(32), T.int64(1), n), "float16")
+    # with T.block("root"):
+    var_T_divide_intermediate = T.alloc_buffer((T.int64(1), T.int64(32), T.int64(1), n), "float16")
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(32), T.int64(1), n):
+        with T.block("T_divide"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(lv196[v_ax0, v_ax1, v_ax2, v_ax3])
+            T.writes(var_T_divide_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_divide_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv196[v_ax0, v_ax1, v_ax2, v_ax3] * T.float16(0.088397790055248615)
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(32), T.int64(1), n):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(var_T_divide_intermediate[v_ax0, v_ax1, v_ax2, v_ax3], lv1486[v_ax0, T.int64(0), v_ax2, v_ax3])
+            T.writes(var_T_add_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_add_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = var_T_divide_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] + lv1486[v_ax0, T.int64(0), v_ax2, v_ax3]
+
+
+@T.prim_func
+def softmax1(var_A: T.handle, var_T_softmax_norm: T.handle):
+    T.func_attr({"op_pattern": 4, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), T.int64(32), T.int64(1), n), "float16")
+    T_softmax_norm = T.match_buffer(var_T_softmax_norm, (T.int64(1), T.int64(32), T.int64(1), n), "float16")
+    # with T.block("root"):
+    T_softmax_maxelem = T.alloc_buffer((T.int64(1), T.int64(32), T.int64(1)), "float16")
+    T_softmax_exp = T.alloc_buffer((T.int64(1), T.int64(32), T.int64(1), n), "float16")
+    T_softmax_expsum = T.alloc_buffer((T.int64(1), T.int64(32), T.int64(1)), "float16")
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(32), T.int64(1), n):
+        with T.block("T_softmax_maxelem"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(A[v_i0, v_i1, v_i2, v_k])
+            T.writes(T_softmax_maxelem[v_i0, v_i1, v_i2])
+            with T.init():
+                T_softmax_maxelem[v_i0, v_i1, v_i2] = T.float16(-65504)
+            T_softmax_maxelem[v_i0, v_i1, v_i2] = T.max(T_softmax_maxelem[v_i0, v_i1, v_i2], A[v_i0, v_i1, v_i2, v_k])
+    for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(32), T.int64(1), n):
+        with T.block("T_softmax_exp"):
+            v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+            T.reads(A[v_i0, v_i1, v_i2, v_i3], T_softmax_maxelem[v_i0, v_i1, v_i2])
+            T.writes(T_softmax_exp[v_i0, v_i1, v_i2, v_i3])
+            T_softmax_exp[v_i0, v_i1, v_i2, v_i3] = T.exp(A[v_i0, v_i1, v_i2, v_i3] - T_softmax_maxelem[v_i0, v_i1, v_i2])
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(32), T.int64(1), n):
+        with T.block("T_softmax_expsum"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_i2, v_k])
+            T.writes(T_softmax_expsum[v_i0, v_i1, v_i2])
+            with T.init():
+                T_softmax_expsum[v_i0, v_i1, v_i2] = T.float16(0)
+            T_softmax_expsum[v_i0, v_i1, v_i2] = T_softmax_expsum[v_i0, v_i1, v_i2] + T_softmax_exp[v_i0, v_i1, v_i2, v_k]
+    for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(32), T.int64(1), n):
+        with T.block("T_softmax_norm"):
+            v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_i2, v_i3], T_softmax_expsum[v_i0, v_i1, v_i2])
+            T.writes(T_softmax_norm[v_i0, v_i1, v_i2, v_i3])
+            T.block_attr({"axis": 3})
+            T_softmax_norm[v_i0, v_i1, v_i2, v_i3] = T_softmax_exp[v_i0, v_i1, v_i2, v_i3] / T_softmax_expsum[v_i0, v_i1, v_i2]
+
+
+@T.prim_func
+def matmul1(var_A: T.handle, var_B: T.handle, matmul: T.Buffer((T.int64(1), T.int64(32), T.int64(1), T.int64(128)), "float16")):
+    T.func_attr({"op_pattern": 4, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), T.int64(32), T.int64(1), n), "float16")
+    B = T.match_buffer(var_B, (T.int64(1), T.int64(32), n, T.int64(128)), "float16")
+    # with T.block("root"):
+    for i0, i1, i2, i3, k in T.grid(T.int64(1), T.int64(32), T.int64(1), T.int64(128), n):
+        with T.block("matmul"):
+            v_i0, v_i1, v_i2, v_i3, v_k = T.axis.remap("SSSSR", [i0, i1, i2, i3, k])
+            T.reads(A[v_i0, v_i1, v_i2, v_k], B[v_i0, v_i1, v_k, v_i3])
+            T.writes(matmul[v_i0, v_i1, v_i2, v_i3])
+            with T.init():
+                matmul[v_i0, v_i1, v_i2, v_i3] = T.float16(0)
+            matmul[v_i0, v_i1, v_i2, v_i3] = matmul[v_i0, v_i1, v_i2, v_i3] + A[v_i0, v_i1, v_i2, v_k] * B[v_i0, v_i1, v_k, v_i3]
+
+
+@T.prim_func
+def fused_transpose3_reshape8(lv1517: T.Buffer((T.int64(1), T.int64(32), T.int64(1), T.int64(128)), "float16"), var_T_reshape_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16")):
+    T.func_attr({"tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    var_T_transpose_intermediate = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(32), T.int64(128)), "float16")
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), T.int64(32), T.int64(128)):
+        with T.block("T_transpose"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(lv1517[v_ax0, v_ax2, v_ax1, v_ax3])
+            T.writes(var_T_transpose_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_transpose_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv1517[v_ax0, v_ax2, v_ax1, v_ax3]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_transpose_intermediate[T.int64(0), T.int64(0), v_ax2 % T.int64(4096) // T.int64(128), v_ax2 % T.int64(128)])
+            T.writes(var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_reshape_intermediate[v_ax0, v_ax1, v_ax2] = var_T_transpose_intermediate[T.int64(0), T.int64(0), v_ax2 % T.int64(4096) // T.int64(128), v_ax2 % T.int64(128)]
+
+
+@T.prim_func
+def fused_silu1_multiply1(lv197: T.Buffer((T.int64(1), T.int64(1), T.int64(11008)), "float16"), lv198: T.Buffer((T.int64(1), T.int64(1), T.int64(11008)), "float16"), var_T_multiply_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(11008)), "float16")):
+    T.func_attr({"tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    compute = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(11008)), "float16")
+    var_T_multiply_intermediate_1 = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(11008)), "float16")
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(lv197[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.sigmoid(lv197[v_i0, v_i1, v_i2])
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_multiply"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv197[v_ax0, v_ax1, v_ax2], compute[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] = lv197[v_ax0, v_ax1, v_ax2] * compute[v_ax0, v_ax1, v_ax2]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(11008)):
+        with T.block("T_multiply_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2], lv198[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2] = var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] * lv198[v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def slice1(A: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16"), slice: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16")):
+    T.func_attr({"op_pattern": 1, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for i, j, k in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("slice"):
+            v_i, v_j, v_k = T.axis.remap("SSS", [i, j, k])
+            T.reads(A[v_i, T.int64(0), v_k])
+            T.writes(slice[v_i, v_j, v_k])
+            slice[v_i, v_j, v_k] = A[v_i, T.int64(0), v_k]
+
+
+@T.prim_func
+def cast(A: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float16"), compute: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32")):
+    T.func_attr({"op_pattern": 0, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(A[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.Cast("float32", A[v_i0, v_i1, v_i2])
+
+
+@T.prim_func
+def reshape(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n), "int32")
+    T_reshape = T.match_buffer(var_T_reshape, (n,), "int32")
+    # with T.block("root"):
+    for ax0 in range(n):
+        with T.block("T_reshape"):
+            v_ax0 = T.axis.spatial(n, ax0)
+            T.reads(A[T.int64(0), v_ax0 % n])
+            T.writes(T_reshape[v_ax0])
+            T_reshape[v_ax0] = A[T.int64(0), v_ax0 % n]
+
+
+@T.prim_func
+def take(A: T.Buffer((T.int64(32000), T.int64(4096)), "float16"), var_B: T.handle, var_T_take: T.handle):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    B = T.match_buffer(var_B, (n,), "int32")
+    T_take = T.match_buffer(var_T_take, (n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for ax0, ax1 in T.grid(n, T.int64(4096)):
+        with T.block("T_take"):
+            v_ax0, v_ax1 = T.axis.remap("SS", [ax0, ax1])
+            T.reads(A[B[v_ax0], v_ax1], B[v_ax0])
+            T.writes(T_take[v_ax0, v_ax1])
+            T_take[v_ax0, v_ax1] = A[B[v_ax0], v_ax1]
+
+
+@T.prim_func
+def reshape1(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (n, T.int64(4096)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[(v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(4096)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[(v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(4096)]
+
+
+@T.prim_func
+def fused_min_max_triu_te_broadcast_to(p_output0: T.handle, n: T.int64):
+    T.func_attr({"tir.noalias": T.bool(True)})
+    var_T_broadcast_to_intermediate = T.match_buffer(p_output0, (T.int64(1), T.int64(1), n, n), "float16")
+    # with T.block("root"):
+    var_make_diag_mask_te_intermediate = T.alloc_buffer((n, n), "float16")
+    for i, j in T.grid(n, n):
+        with T.block("make_diag_mask_te"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads()
+            T.writes(var_make_diag_mask_te_intermediate[v_i, v_j])
+            var_make_diag_mask_te_intermediate[v_i, v_j] = T.Select(v_i < v_j, T.float16(-65504), T.float16(0))
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(1), n, n):
+        with T.block("T_broadcast_to"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(var_make_diag_mask_te_intermediate[v_ax2, v_ax3])
+            T.writes(var_T_broadcast_to_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_broadcast_to_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = var_make_diag_mask_te_intermediate[v_ax2, v_ax3]
+
+
+@T.prim_func
+def extend_te(var_A: T.handle, var_concat_te: T.handle):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), T.int64(1), n, n), "float16")
+    m = T.int64()
+    concat_te = T.match_buffer(var_concat_te, (T.int64(1), T.int64(1), n, m), "float16")
+    # with T.block("root"):
+    for b, _, i, j in T.grid(T.int64(1), T.int64(1), n, m):
+        with T.block("concat_te"):
+            v_b, v__, v_i, v_j = T.axis.remap("SSSS", [b, _, i, j])
+            T.reads(A[v_b, v__, v_i, v_j + n - m])
+            T.writes(concat_te[v_b, v__, v_i, v_j])
+            concat_te[v_b, v__, v_i, v_j] = T.if_then_else(v_j < m - n, T.float16(0), A[v_b, v__, v_i, v_j + n - m])
+
+
+@T.prim_func
+def rms_norm(var_A: T.handle, B: T.Buffer((T.int64(4096),), "float16"), var_rms_norm: T.handle):
+    T.func_attr({"op_pattern": 4, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(4096)), "float16")
+    rms_norm_1 = T.match_buffer(var_rms_norm, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    Ared_temp = T.alloc_buffer((T.int64(1), n))
+    for bsz, i, k in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("Ared_temp"):
+            v_bsz, v_i, v_k = T.axis.remap("SSR", [bsz, i, k])
+            T.reads(A[v_bsz, v_i, v_k])
+            T.writes(Ared_temp[v_bsz, v_i])
+            with T.init():
+                Ared_temp[v_bsz, v_i] = T.float32(0)
+            Ared_temp[v_bsz, v_i] = Ared_temp[v_bsz, v_i] + T.Cast("float32", A[v_bsz, v_i, v_k]) * T.Cast("float32", A[v_bsz, v_i, v_k])
+    for bsz, i, k in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("rms_norm"):
+            v_bsz, v_i, v_k = T.axis.remap("SSS", [bsz, i, k])
+            T.reads(B[v_k], A[v_bsz, v_i, v_k], Ared_temp[v_bsz, v_i])
+            T.writes(rms_norm_1[v_bsz, v_i, v_k])
+            rms_norm_1[v_bsz, v_i, v_k] = T.Cast("float16", T.Cast("float32", B[v_k]) * (T.Cast("float32", A[v_bsz, v_i, v_k]) / T.sqrt(Ared_temp[v_bsz, v_i] * T.float32(0.000244140625) + T.float32(9.9999999999999995e-07))))
+
+
+@T.prim_func
+def reshape2(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(4096)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), n, T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[T.int64(0), ((v_ax2 * T.int64(128) + v_ax3) // T.int64(4096) + v_ax0 * n + v_ax1) % n, (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[T.int64(0), ((v_ax2 * T.int64(128) + v_ax3) // T.int64(4096) + v_ax0 * n + v_ax1) % n, (v_ax2 * T.int64(128) + v_ax3) % T.int64(4096)]
+
+
+@T.prim_func
+def rotary_embedding(var_A: T.handle, B: T.Buffer((T.int64(2048), T.int64(128)), "float16"), C: T.Buffer((T.int64(2048), T.int64(128)), "float16"), var_rotary: T.handle, m: T.int64):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    rotary = T.match_buffer(var_rotary, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    # with T.block("root"):
+    for i0, i1, i2, i3 in T.grid(T.int64(1), n, T.int64(32), T.int64(128)):
+        with T.block("rotary"):
+            v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+            T.reads(B[m + v_i1 - n, v_i3], A[v_i0, v_i1, v_i2, v_i3 - T.int64(64):v_i3 - T.int64(64) + T.int64(129)], C[m + v_i1 - n, v_i3])
+            T.writes(rotary[v_i0, v_i1, v_i2, v_i3])
+            rotary[v_i0, v_i1, v_i2, v_i3] = B[m + v_i1 - n, v_i3] * A[v_i0, v_i1, v_i2, v_i3] + C[m + v_i1 - n, v_i3] * T.Select(T.int64(64) <= v_i3, A[v_i0, v_i1, v_i2, v_i3 - T.int64(64)], A[v_i0, v_i1, v_i2, v_i3 + T.int64(64)] * T.float16(-1))
+
+
+@T.prim_func
+def squeeze(var_A: T.handle, var_T_squeeze: T.handle):
+    T.func_attr({"op_pattern": 1, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    T_squeeze = T.match_buffer(var_T_squeeze, (n, T.int64(32), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(n, T.int64(32), T.int64(128)):
+        with T.block("T_squeeze"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), v_ax0, v_ax1, v_ax2])
+            T.writes(T_squeeze[v_ax0, v_ax1, v_ax2])
+            T_squeeze[v_ax0, v_ax1, v_ax2] = A[T.int64(0), v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def reshape3(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    m = T.int64()
+    A = T.match_buffer(var_A, (m, T.int64(32), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), m, T.int64(32), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), m, T.int64(32), T.int64(128)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * m + v_ax1) % m, (v_ax3 // T.int64(128) + v_ax2) % T.int64(32), v_ax3 % T.int64(128)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_reshape[v_ax0, v_ax1, v_ax2, v_ax3] = A[((v_ax3 // T.int64(128) + v_ax2) // T.int64(32) + v_ax0 * m + v_ax1) % m, (v_ax3 // T.int64(128) + v_ax2) % T.int64(32), v_ax3 % T.int64(128)]
+
+
+@T.prim_func
+def transpose(var_A: T.handle, var_T_transpose: T.handle):
+    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    T_transpose = T.match_buffer(var_T_transpose, (T.int64(1), T.int64(32), n, T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(32), n, T.int64(128)):
+        with T.block("T_transpose"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[v_ax0, v_ax2, v_ax1, v_ax3])
+            T.writes(T_transpose[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_transpose[v_ax0, v_ax1, v_ax2, v_ax3] = A[v_ax0, v_ax2, v_ax1, v_ax3]
+
+
+@T.prim_func
+def fused_divide_add(p_lv3: T.handle, p_lv5: T.handle, p_output0: T.handle):
+    T.func_attr({"tir.noalias": T.bool(True)})
+    n, m = T.int64(), T.int64()
+    lv3 = T.match_buffer(p_lv3, (T.int64(1), T.int64(32), n, m), "float16")
+    lv5 = T.match_buffer(p_lv5, (T.int64(1), T.int64(1), n, m), "float16")
+    var_T_add_intermediate = T.match_buffer(p_output0, (T.int64(1), T.int64(32), n, m), "float16")
+    # with T.block("root"):
+    var_T_divide_intermediate = T.alloc_buffer((T.int64(1), T.int64(32), n, m), "float16")
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(32), n, m):
+        with T.block("T_divide"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(lv3[v_ax0, v_ax1, v_ax2, v_ax3])
+            T.writes(var_T_divide_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_divide_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = lv3[v_ax0, v_ax1, v_ax2, v_ax3] * T.float16(0.088397790055248615)
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), T.int64(32), n, m):
+        with T.block("T_add"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(var_T_divide_intermediate[v_ax0, v_ax1, v_ax2, v_ax3], lv5[v_ax0, T.int64(0), v_ax2, v_ax3])
+            T.writes(var_T_add_intermediate[v_ax0, v_ax1, v_ax2, v_ax3])
+            var_T_add_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] = var_T_divide_intermediate[v_ax0, v_ax1, v_ax2, v_ax3] + lv5[v_ax0, T.int64(0), v_ax2, v_ax3]
+
+
+@T.prim_func
+def softmax(var_A: T.handle, var_T_softmax_norm: T.handle):
+    T.func_attr({"op_pattern": 4, "tir.noalias": T.bool(True)})
+    n, m = T.int64(), T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), T.int64(32), n, m), "float16")
+    T_softmax_norm = T.match_buffer(var_T_softmax_norm, (T.int64(1), T.int64(32), n, m), "float16")
+    # with T.block("root"):
+    T_softmax_maxelem = T.alloc_buffer((T.int64(1), T.int64(32), n), "float16")
+    T_softmax_exp = T.alloc_buffer((T.int64(1), T.int64(32), n, m), "float16")
+    T_softmax_expsum = T.alloc_buffer((T.int64(1), T.int64(32), n), "float16")
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(32), n, m):
+        with T.block("T_softmax_maxelem"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(A[v_i0, v_i1, v_i2, v_k])
+            T.writes(T_softmax_maxelem[v_i0, v_i1, v_i2])
+            with T.init():
+                T_softmax_maxelem[v_i0, v_i1, v_i2] = T.float16(-65504)
+            T_softmax_maxelem[v_i0, v_i1, v_i2] = T.max(T_softmax_maxelem[v_i0, v_i1, v_i2], A[v_i0, v_i1, v_i2, v_k])
+    for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(32), n, m):
+        with T.block("T_softmax_exp"):
+            v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+            T.reads(A[v_i0, v_i1, v_i2, v_i3], T_softmax_maxelem[v_i0, v_i1, v_i2])
+            T.writes(T_softmax_exp[v_i0, v_i1, v_i2, v_i3])
+            T_softmax_exp[v_i0, v_i1, v_i2, v_i3] = T.exp(A[v_i0, v_i1, v_i2, v_i3] - T_softmax_maxelem[v_i0, v_i1, v_i2])
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(32), n, m):
+        with T.block("T_softmax_expsum"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_i2, v_k])
+            T.writes(T_softmax_expsum[v_i0, v_i1, v_i2])
+            with T.init():
+                T_softmax_expsum[v_i0, v_i1, v_i2] = T.float16(0)
+            T_softmax_expsum[v_i0, v_i1, v_i2] = T_softmax_expsum[v_i0, v_i1, v_i2] + T_softmax_exp[v_i0, v_i1, v_i2, v_k]
+    for i0, i1, i2, i3 in T.grid(T.int64(1), T.int64(32), n, m):
+        with T.block("T_softmax_norm"):
+            v_i0, v_i1, v_i2, v_i3 = T.axis.remap("SSSS", [i0, i1, i2, i3])
+            T.reads(T_softmax_exp[v_i0, v_i1, v_i2, v_i3], T_softmax_expsum[v_i0, v_i1, v_i2])
+            T.writes(T_softmax_norm[v_i0, v_i1, v_i2, v_i3])
+            T.block_attr({"axis": 3})
+            T_softmax_norm[v_i0, v_i1, v_i2, v_i3] = T_softmax_exp[v_i0, v_i1, v_i2, v_i3] / T_softmax_expsum[v_i0, v_i1, v_i2]
+
+
+@T.prim_func
+def matmul(var_A: T.handle, var_B: T.handle, var_matmul: T.handle):
+    T.func_attr({"op_pattern": 4, "tir.noalias": T.bool(True)})
+    n, m = T.int64(), T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), T.int64(32), n, m), "float16")
+    B = T.match_buffer(var_B, (T.int64(1), T.int64(32), m, T.int64(128)), "float16")
+    matmul_1 = T.match_buffer(var_matmul, (T.int64(1), T.int64(32), n, T.int64(128)), "float16")
+    # with T.block("root"):
+    for i0, i1, i2, i3, k in T.grid(T.int64(1), T.int64(32), n, T.int64(128), m):
+        with T.block("matmul"):
+            v_i0, v_i1, v_i2, v_i3, v_k = T.axis.remap("SSSSR", [i0, i1, i2, i3, k])
+            T.reads(A[v_i0, v_i1, v_i2, v_k], B[v_i0, v_i1, v_k, v_i3])
+            T.writes(matmul_1[v_i0, v_i1, v_i2, v_i3])
+            with T.init():
+                matmul_1[v_i0, v_i1, v_i2, v_i3] = T.float16(0)
+            matmul_1[v_i0, v_i1, v_i2, v_i3] = matmul_1[v_i0, v_i1, v_i2, v_i3] + A[v_i0, v_i1, v_i2, v_k] * B[v_i0, v_i1, v_k, v_i3]
+
+
+@T.prim_func
+def transpose1(var_A: T.handle, var_T_transpose: T.handle):
+    T.func_attr({"op_pattern": 2, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), T.int64(32), n, T.int64(128)), "float16")
+    T_transpose = T.match_buffer(var_T_transpose, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2, ax3 in T.grid(T.int64(1), n, T.int64(32), T.int64(128)):
+        with T.block("T_transpose"):
+            v_ax0, v_ax1, v_ax2, v_ax3 = T.axis.remap("SSSS", [ax0, ax1, ax2, ax3])
+            T.reads(A[v_ax0, v_ax2, v_ax1, v_ax3])
+            T.writes(T_transpose[v_ax0, v_ax1, v_ax2, v_ax3])
+            T_transpose[v_ax0, v_ax1, v_ax2, v_ax3] = A[v_ax0, v_ax2, v_ax1, v_ax3]
+
+
+@T.prim_func
+def reshape4(var_A: T.handle, var_T_reshape: T.handle):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(32), T.int64(128)), "float16")
+    T_reshape = T.match_buffer(var_T_reshape, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(4096)):
+        with T.block("T_reshape"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(A[T.int64(0), (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(4096) // T.int64(128), v_ax2 % T.int64(128)])
+            T.writes(T_reshape[v_ax0, v_ax1, v_ax2])
+            T_reshape[v_ax0, v_ax1, v_ax2] = A[T.int64(0), (v_ax2 // T.int64(4096) + v_ax0 * n + v_ax1) % n, v_ax2 % T.int64(4096) // T.int64(128), v_ax2 % T.int64(128)]
+
+
+@T.prim_func
+def fused_silu_multiply(p_lv4: T.handle, p_lv5: T.handle, p_output0: T.handle):
+    T.func_attr({"tir.noalias": T.bool(True)})
+    n = T.int64()
+    lv4 = T.match_buffer(p_lv4, (T.int64(1), n, T.int64(11008)), "float16")
+    lv5 = T.match_buffer(p_lv5, (T.int64(1), n, T.int64(11008)), "float16")
+    var_T_multiply_intermediate = T.match_buffer(p_output0, (T.int64(1), n, T.int64(11008)), "float16")
+    # with T.block("root"):
+    compute = T.alloc_buffer((T.int64(1), n, T.int64(11008)), "float16")
+    var_T_multiply_intermediate_1 = T.alloc_buffer((T.int64(1), n, T.int64(11008)), "float16")
+    for i0, i1, i2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(lv4[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.sigmoid(lv4[v_i0, v_i1, v_i2])
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_multiply"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(lv4[v_ax0, v_ax1, v_ax2], compute[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] = lv4[v_ax0, v_ax1, v_ax2] * compute[v_ax0, v_ax1, v_ax2]
+    for ax0, ax1, ax2 in T.grid(T.int64(1), n, T.int64(11008)):
+        with T.block("T_multiply_1"):
+            v_ax0, v_ax1, v_ax2 = T.axis.remap("SSS", [ax0, ax1, ax2])
+            T.reads(var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2], lv5[v_ax0, v_ax1, v_ax2])
+            T.writes(var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2])
+            var_T_multiply_intermediate[v_ax0, v_ax1, v_ax2] = var_T_multiply_intermediate_1[v_ax0, v_ax1, v_ax2] * lv5[v_ax0, v_ax1, v_ax2]
+
+
+@T.prim_func
+def slice(var_A: T.handle, slice_1: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float16")):
+    T.func_attr({"op_pattern": 8, "tir.noalias": T.bool(True)})
+    n = T.int64()
+    A = T.match_buffer(var_A, (T.int64(1), n, T.int64(4096)), "float16")
+    # with T.block("root"):
+    for i, j, k in T.grid(T.int64(1), T.int64(1), T.int64(4096)):
+        with T.block("slice"):
+            v_i, v_j, v_k = T.axis.remap("SSS", [i, j, k])
+            T.reads(A[v_i, n - T.int64(1), v_k])
+            T.writes(slice_1[v_i, v_j, v_k])
+            slice_1[v_i, v_j, v_k] = A[v_i, n - T.int64(1), v_k]
+
+
+@T.prim_func
+def cast(A: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float16"), compute: T.Buffer((T.int64(1), T.int64(1), T.int64(32000)), "float32")):
+    T.func_attr({"op_pattern": 0, "tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    for i0, i1, i2 in T.grid(T.int64(1), T.int64(1), T.int64(32000)):
+        with T.block("compute"):
+            v_i0, v_i1, v_i2 = T.axis.remap("SSS", [i0, i1, i2])
+            T.reads(A[v_i0, v_i1, v_i2])
+            T.writes(compute[v_i0, v_i1, v_i2])
+            compute[v_i0, v_i1, v_i2] = T.Cast("float32", A[v_i0, v_i1, v_i2])
+
+DlightBench.register_bench_workload(reshape5, 'vicuna_v1_7b_fp16', 'reshape5')
+DlightBench.register_bench_workload(take1, 'vicuna_v1_7b_fp16', 'take1')
+DlightBench.register_bench_workload(reshape6, 'vicuna_v1_7b_fp16', 'reshape6')
+DlightBench.register_bench_workload(full, 'vicuna_v1_7b_fp16', 'full')
+DlightBench.register_bench_workload(rms_norm1, 'vicuna_v1_7b_fp16', 'rms_norm1')
+DlightBench.register_bench_workload(reshape7, 'vicuna_v1_7b_fp16', 'reshape7')
+DlightBench.register_bench_workload(fused_reshape7_squeeze1, 'vicuna_v1_7b_fp16', 'fused_reshape7_squeeze1')
+DlightBench.register_bench_workload(rotary_embedding1, 'vicuna_v1_7b_fp16', 'rotary_embedding1')
+DlightBench.register_bench_workload(squeeze1, 'vicuna_v1_7b_fp16', 'squeeze1')
+DlightBench.register_bench_workload(reshape3, 'vicuna_v1_7b_fp16', 'reshape3')
+DlightBench.register_bench_workload(transpose2, 'vicuna_v1_7b_fp16', 'transpose2')
+DlightBench.register_bench_workload(transpose, 'vicuna_v1_7b_fp16', 'transpose')
+DlightBench.register_bench_workload(fused_divide1_add1, 'vicuna_v1_7b_fp16', 'fused_divide1_add1')
+DlightBench.register_bench_workload(softmax1, 'vicuna_v1_7b_fp16', 'softmax1')
+DlightBench.register_bench_workload(matmul1, 'vicuna_v1_7b_fp16', 'matmul1')
+DlightBench.register_bench_workload(fused_transpose3_reshape8, 'vicuna_v1_7b_fp16', 'fused_transpose3_reshape8')
+DlightBench.register_bench_workload(fused_silu1_multiply1, 'vicuna_v1_7b_fp16', 'fused_silu1_multiply1')
+DlightBench.register_bench_workload(slice1, 'vicuna_v1_7b_fp16', 'slice1')
+DlightBench.register_bench_workload(cast, 'vicuna_v1_7b_fp16', 'cast')
+DlightBench.register_bench_workload(reshape, 'vicuna_v1_7b_fp16', 'reshape')
+DlightBench.register_bench_workload(take, 'vicuna_v1_7b_fp16', 'take')
+DlightBench.register_bench_workload(reshape1, 'vicuna_v1_7b_fp16', 'reshape1')
+DlightBench.register_bench_workload(fused_min_max_triu_te_broadcast_to, 'vicuna_v1_7b_fp16', 'fused_min_max_triu_te_broadcast_to')
+DlightBench.register_bench_workload(extend_te, 'vicuna_v1_7b_fp16', 'extend_te')
+DlightBench.register_bench_workload(rms_norm, 'vicuna_v1_7b_fp16', 'rms_norm')
+DlightBench.register_bench_workload(reshape2, 'vicuna_v1_7b_fp16', 'reshape2')
+DlightBench.register_bench_workload(rotary_embedding, 'vicuna_v1_7b_fp16', 'rotary_embedding')
+DlightBench.register_bench_workload(squeeze, 'vicuna_v1_7b_fp16', 'squeeze')
+DlightBench.register_bench_workload(reshape3, 'vicuna_v1_7b_fp16', 'reshape3')
+DlightBench.register_bench_workload(transpose, 'vicuna_v1_7b_fp16', 'transpose')
+DlightBench.register_bench_workload(fused_divide_add, 'vicuna_v1_7b_fp16', 'fused_divide_add')
+DlightBench.register_bench_workload(softmax, 'vicuna_v1_7b_fp16', 'softmax')
+DlightBench.register_bench_workload(matmul, 'vicuna_v1_7b_fp16', 'matmul')
+DlightBench.register_bench_workload(transpose1, 'vicuna_v1_7b_fp16', 'transpose1')
+DlightBench.register_bench_workload(reshape4, 'vicuna_v1_7b_fp16', 'reshape4')
+DlightBench.register_bench_workload(fused_silu_multiply, 'vicuna_v1_7b_fp16', 'fused_silu_multiply')
+DlightBench.register_bench_workload(slice, 'vicuna_v1_7b_fp16', 'slice')
+DlightBench.register_bench_workload(cast, 'vicuna_v1_7b_fp16', 'cast')


### PR DESCRIPTION
This PR introduces a set of interface to benchmark PrimFuncs on different targets, with given shape sampling function. The PrimFuncs are collected from various models for easy benchmarking.

Demo usage:
```python
from typing import Dict, Set

import tvm
import tvm.dlight as dl

from dlight_bench import DlightBench


def factorized(factor: int, minimum: int):
    """Factorized dynamic shape variable sample function factory."""

    def sample_dym_var_sequential(
        dym_vars: Set[str], sample_idx: int, _: int
    ) -> Dict[str, int]:
        """
        Sequential dynamic shape variable sample function.
        Sample a sequential value for each dynamic shape variable.

        Parameters
        ----------
        dym_vars : Set[str]
            Dynamic shape variable set, e.g., {"n", "m"}
        sample_idx : int
            Sample index denotes the index the function is called for the same
            dynamic shape variable dictionary & function.
        sample_num : int
            Sample number denotes the total number of samples.

        Returns
        -------
        result : Dict[str, int]
            Dynamic shape variable sample, e.g., {"n": 64, "m": 128}
        """
        results = {}
        cnt = 1
        for var in dym_vars:
            results[var] = 2 ** (sample_idx // cnt % factor + minimum)
            cnt *= factor
        return results

    return sample_dym_var_sequential


with tvm.target.Target("nvidia/geforce-rtx-3070"):
    DlightBench.benchmark(
        "vicuna_v1_7b_fp16",
        func_names=["matmul"],
        passes=[tvm.tir.transform.DefaultGPUSchedule()],
        sample_func=factorized(5, 5),
        sample_num_per_func=10,
    )
    DlightBench.benchmark(
        "vicuna_v1_7b_fp16",
        func_names=["matmul"],
        passes=[dl.ApplyDefaultSchedule(dl.gpu.Fallback())],
        sample_func=factorized(5, 5),
        sample_num_per_func=10,
    )
```

Sample Output:
```
Model: vicuna_v1_7b_fp16
Target: cuda -keys=cuda,gpu -arch=sm_86 -max_num_threads=1024 -max_shared_memory_per_block=49152 -max_threads_per_block=1024 -registers_per_block=65536 -thread_warp_size=32
Category: All

Benchmarking matmul:
Applying pass: Run Module pass: DefaultGPUSchedule at the optimization level 0
         InputInfo     Time(us)  Memory(GB/s)
0   m = 32, n = 32    42.463408     12.936230
1   m = 64, n = 32    77.090732     11.084240
2  m = 128, n = 32   149.913021      9.771291
3  m = 256, n = 32   295.345732      9.092892
4  m = 512, n = 32   810.619839      6.324732
5   m = 32, n = 64    76.766872     11.131002
6   m = 64, n = 64   148.433530      8.223904
7  m = 128, n = 64   291.680747      6.696105
8  m = 256, n = 64   577.855315      5.914921
9  m = 512, n = 64  1600.398222      3.966298



Model: vicuna_v1_7b_fp16
Target: cuda -keys=cuda,gpu -arch=sm_86 -max_num_threads=1024 -max_shared_memory_per_block=49152 -max_threads_per_block=1024 -registers_per_block=65536 -thread_warp_size=32
Category: All

Benchmarking matmul:
Applying pass: Run Module pass: ApplyDefaultSchedule at the optimization level 0
         InputInfo    Time(us)  Memory(GB/s)
0   m = 32, n = 32   11.091237     49.527065
1   m = 64, n = 32   18.765057     45.536350
2  m = 128, n = 32   34.053055     43.016515
3  m = 256, n = 32   65.135740     41.230005
4  m = 512, n = 32  154.466162     33.191432
5   m = 32, n = 64   21.159738     40.382929
6   m = 64, n = 64   36.526730     33.419447
7  m = 128, n = 64   67.385378     28.984404
8  m = 256, n = 64  129.814930     26.329551
9  m = 512, n = 64  303.769992     20.896258
```